### PR TITLE
Update Contributing link.

### DIFF
--- a/Slic3rSupport.tex
+++ b/Slic3rSupport.tex
@@ -61,7 +61,7 @@ If a bug may have been found in the software then an issue may be raised in the 
 
 \textbf{Please} take the time to read through the existing issues to see whether the problem has already been submitted.  Also make sure that the problem is a bug in the application, support related questions should not be submitted.
 
-If the bug appears to be unreported then please read the bug report guide before submitting: \url{https://github.com/alexrj/Slic3r/wiki/Quick-guide-to-writing-good-bug-reports}.
+If the bug appears to be unreported then please read the bug report guide before submitting: \url{http://git.io/11Hy_w}.
 
 % subsection issue_tracker (end)
 


### PR DESCRIPTION
Used git.io to shorten url to fix URL rendering and to prevent it from running off the page.
URL updated to point to: https://github.com/alexrj/Slic3r/blob/master/CONTRIBUTING.md
