### PR TITLE
MAI: update script `make-pdf`

### DIFF
--- a/list_files.py
+++ b/list_files.py
@@ -1,0 +1,27 @@
+"""List Markdown files included in `toc.md`."""
+import re
+
+
+TOC_FILE_NAME = 'toc.md'
+
+
+def list_md_files():
+    with open(TOC_FILE_NAME, 'r') as f:
+        md = f.readlines()
+    files = set()
+    for line in md:
+        if not line.startswith('    *'):
+            continue
+        s = line.split('(')[1].split(')')[0].split('#')[0]
+        assert s.startswith('/'), s
+        s = s[1:]
+        if s in files:
+            continue
+        if s.startswith('libslic3r-doc'):
+            continue
+        files.add(s)
+        print(s)
+
+
+if __name__ == '__main__':
+    list_md_files()

--- a/make-pdf
+++ b/make-pdf
@@ -4,7 +4,7 @@
 #
 # apt-get install pandoc
 # apt-get install texlive-xetex
-# apt-get install imagemagick
+# apt-get install pdftk-java
 
 echo create tmp directory with sources: src.pdf
 rm -rf    src.pdf
@@ -16,22 +16,22 @@ mkdir     tmp
 echo create tmp direcetory for images
 for DIR in $(find ../src -type d -name images); do cp -R $DIR .; done
 
-echo create create book.pdf
+echo create book.pdf
 
 FILES=""
 
-for FILE in $(grep "^    *" toc.md | cut -d/ -f2- | tr ')' '#' | cut -d'#' -f1 | uniq)
+for FILE in $(python ../list_files.py)
 do
 	SRC=${FILE}.md
 	DST=$(basename $SRC .md).pdf
 
-	printf "create %-32s from %s\n" ${DST} ${SRC}.md
-	pandoc ${SRC} -o tmp/${DST}
+	printf "create %-32s from %s\n" ${DST} ${SRC}
+	pandoc ${SRC} --latex-engine=xelatex -o tmp/${DST}
 
 	FILES="$FILES tmp/$DST"
 done
 
 echo create slic3r-book.pdf
-convert -quality 100 -density 300x300 $FILES slic3r-book.pdf
+pdftk $FILES cat output slic3r-book.pdf
 
 rm -rf tmp


### PR DESCRIPTION
- use the Python script `list_files.py` to list
  the paths of Markdown files to typeset,
  because one of the headers in the table of contents
  `src/toc.md` contains a `/`, resulting in
  an erroneous path passed to `pandoc`

- pass to `pandoc` the option `--latex-engine=xelatex`
  because one of the source files contains a UTF8 character

- use `pdftk`, which is faster than `convert`

- fix typos in `echo` and `printf` messages