### PR TITLE
Edits for correctness, clarity, grammar, spelling

### DIFF
--- a/src/advanced/command-line.md
+++ b/src/advanced/command-line.md
@@ -1,6 +1,7 @@
 % Command Line Usage
 
-Slic3r can be used as a command line tool. It provides you with great flexibility so that you can perform operations in batch or as part of more complex workflows.
+Slic3r can be used as a command line tool. It provides you with great flexibility
+so that you can perform operations in batch or as part of more complex workflows.
 
 ### Actions
 
@@ -10,46 +11,72 @@ The general syntax is:
 
 where ACTION can be one (or more) of the following:
 
-* `--help`: displays the inline help
-* `--export-gcode` (shortcut: `--gcode` or `-g`): slices the given model(s) and exports G-code toolpaths
-* `--export-stl`: exports the given model(s) as STL
-* `--export-amf`: exports the given model(s) as AMF
-* `--export-3mf`: exports the given model(s) as 3MF
-* `--export-obj`: exports the given model(s) as OBJ
-* `--export-pov`: exports the given model(s) as a POV-Ray definition
-* `--export-svg`: slices the given model(s) and exports solid slices as SVG files
-* `--export-sla-svg` (shortcut: `--sla`): slices the given model(s) and exports slices for SLA printers as SVG files (with infill patterns, raft support...)
-* `--info`: outputs information about the model(s)
-* `--save FILE`: saves configuration to the given file
+* `--help` &ndash; displays the inline help
+* `--export-gcode` (shortcut: `--gcode` or `-g`) &ndash; slices the given
+  model(s) and exports G-code toolpaths
+* `--export-stl` &ndash; exports the given model(s) as STL
+* `--export-amf` &ndash; exports the given model(s) as AMF
+* `--export-3mf` &ndash; exports the given model(s) as 3MF
+* `--export-obj` &ndash; exports the given model(s) as OBJ
+* `--export-pov` &ndash; exports the given model(s) as a POV-Ray definition
+* `--export-svg` &ndash; slices the given model(s) and exports solid slices as
+  SVG files
+* `--export-sla-svg` (shortcut: `--sla`) &ndash; slices the given model(s) and
+  exports slices for SLA printers as SVG files (with infill patterns, raft
+  support...)
+* `--info` &ndash; outputs information about the model(s)
+* `--save FILE` &ndash; saves configuration to the given file
 
-If called with no ACTION, the graphical interface will be launched and the supplied models (if any) will be loaded in the plater.
-If multiple actions are be specified, they will be executed in the given order.
-If multiple models are supplied, the requested action will be performed separately for each one.
+If called with no ACTION, the graphical interface will be launched and the
+supplied models (if any) will be loaded in the plater. If multiple actions are
+be specified, they will be executed in the given order. If multiple models are
+supplied, the requested action will be performed separately for each one.
 
 ### Model transform
 
-The following options will affect how the model(s) are transformed before performing the requested action:
+The following options will affect how the model(s) are transformed before
+performing the requested action:
 
-* `--merge` (shortcut: `-m`): the given models will be arranged and then merged into a single one, thus the action will be performed once
-    * if the `--dont-arrange` option is supplied, models will be merged at their original coordinates
-* `--center X,Y`: centers the given model(s) around the given point and also aligns them to *z = 0*
+* `--merge` (shortcut: `-m`) &ndash; the given models will be arranged and then
+  merged into a single one, thus the action will be performed once
+    * if the `--dont-arrange` option is supplied, models will be merged at their
+      original coordinates
+* `--center X,Y` &ndash; centers the given model(s) around the given point and
+  also aligns them to *z = 0*
     * as an alternative, `--align-xy X,Y` aligns the model(s) to the given point
-    * if none of those are specified, `--export-gcode` will center the model around the centroid point of the configured print bed (unless the `--dont-arrange` option is supplied: original coordinates will be used in that case)
+    * if none of those are specified, `--export-gcode` will center the model
+      around the centroid point of the configured print bed (unless the
+      `--dont-arrange` option is supplied: original coordinates will be used in
+      that case)
     * `--export-svg` and `--export-sla-svg` will align to *z = 0* anyway
-* `--scale FACTOR`: the given model(s) will be scaled by the given factor or percentage (the % character determines how the number is parsed)
-* `--scale-to-fit X,Y,Z`: the given model(s) will be scaled to fit the given volume expressed in millimeters
-* `--rotate ANGLE`, `--rotate-x ANGLE`, `--rotate-y ANGLE`: rotates the given model around the Z, X, Y axes by the given degrees
-* `--duplicate NUM`: multiplies the copies of the given model(s)
-* `--duplicate-grid X,Y`: multiplies the copies of the given model(s) by creating a grid (spacing can be customized with `--duplicate-distance`)
-* `--cut Z`: cuts the given model(s) in two halves at the given Z and exports both the resulting models (note that the given coordinate should be relative to the object's bottom and not to its absolute position)
-* `--cut-x X`, `--cut-y Y`: cuts the given model(s) in two halves along the X or Y axis at the given absolute coordinate and exports both resulting models
-* `--cut-grid X,Y`: cuts the given model(s) according to a grid having the given pattern and exports ann the resulting models
-* `--split`: detects unconnected parts in the given model(s) and splits them into separate objects
-* `--repair`: this tries to repair any non-manifold meshes (this option is implicitly added whenever we need to slice the model, i.e. for `--cut*`, `--export-gcode`, `--export-svg`, `--export-sla-svg`)
+* `--scale FACTOR` &ndash; the given model(s) will be scaled by the given factor
+  or percentage (the % character determines how the number is parsed)
+* `--scale-to-fit X,Y,Z` &ndash; the given model(s) will be scaled to fit the
+  given volume expressed in millimeters
+* `--rotate ANGLE`, `--rotate-x ANGLE`, `--rotate-y ANGLE` &ndash; rotates the
+  given model around the Z, X, Y axes by the given degrees
+* `--duplicate NUM` &ndash; multiplies the copies of the given model(s)
+* `--duplicate-grid X,Y` &ndash; multiplies the copies of the given model(s) by
+  creating a grid (spacing can be customized with `--duplicate-distance`)
+* `--cut Z` &ndash; cuts the given model(s) in two halves at the given Z and
+  exports both the resulting models (note that the given coordinate should be
+  relative to the object's bottom and not to its absolute position)
+* `--cut-x X`, `--cut-y Y` &ndash; cuts the given model(s) in two halves along
+  the X or Y axis at the given absolute coordinate and exports both resulting
+  models
+* `--cut-grid X,Y` &ndash; cuts the given model(s) according to a grid having
+  the given pattern and exports all the resulting models
+* `--split` &ndash; detects unconnected parts in the given model(s) and splits
+  them into separate objects
+* `--repair` &ndash; this tries to repair any non-manifold meshes. (This option
+  is implicitly added whenever we need to slice the model, i.e. for `--cut*`,
+  `--export-gcode`, `--export-svg`, `--export-sla-svg`.)
 
 These transform options are applied in the given order.
 
-For convenience, if any of `--cut`, `--cut-x`, `--cut-z`, `--split`, `--repair` is supplied and none of the above actions is specified, `--export-stl` is implicitly assumed.
+For convenience, if any of `--cut`, `--cut-x`, `--cut-z`, `--split`, `--repair`
+is supplied and none of the above actions is specified, `--export-stl` is
+implicitly assumed.
 
 Examples:
 
@@ -65,39 +92,56 @@ slic3r --split cubes.stl
 
 All the `--export-*` actions are affected by the following options:
 
-* `--output FILENAME` (shortcut: `-o`): write output to the given file instead of the default one
-    * if an existing directory is supplied instead of a file, the file will be created inside that directory using the automatically generated file name
-* `--output-filename-format FORMAT`: this is the string pattern used to define the output file if `--output` is not specified. It defaults to `[input_filename_base].EXT` where EXT is the extension of the output format (`gcode`, `stl` etc.). See the documentation about [placeholders](/advanced/placeholder-parser).
-    * when using `--export-svg`, the default format is `[input_filename_base]_[layer_num].svg`
+* `--output FILENAME` (shortcut: `-o`) &ndash; write output to the given file
+  instead of the default one
+    * if an existing directory is supplied instead of a file, the file will be
+      created inside that directory using the automatically generated file name
+* `--output-filename-format FORMAT` &ndash; this is the string pattern used to
+  define the output file if `--output` is not specified. It defaults to
+  `[input_filename_base].EXT` where EXT is the extension of the output format
+  (`gcode`, `stl` etc.). See the documentation about
+  [placeholders](/advanced/placeholder-parser).
+    * when using `--export-svg`, the default format is
+      `[input_filename_base]_[layer_num].svg`
 
 ### Configuration
 
-Configuration options affect toolpath generation (thus `--export-gcode` and `--export-sla-svg`). All the options available in the graphical interface of Slic3r can be used from command line as individual switches.
+Configuration options affect toolpath generation (thus `--export-gcode` and
+`--export-sla-svg`). All the options available in the graphical interface of
+Slic3r can be used from command line as individual switches.
 
 For example:
 
-    slic3r -g my_model.stl --layer-height 0.2
+```
+slic3r -g my_model.stl --layer-height 0.2
+```
 
-This will generate a file named *my_model.gcode* in the same directory as 
+This will generate a file named *my_model.gcode* in the same directory as
 the input STL file. You may want to specify a custom output path:
 
-    slic3r -g my_model.stl --layer-height 0.2 --output /path/to/output.gcode
+```
+slic3r -g my_model.stl --layer-height 0.2 --output /path/to/output.gcode
+```
 
-To get the full listing, reference and defaults of available command line 
+To get the full listing, reference and defaults of available command line
 switches, just run:
 
-    slic3r --help-options
+```
+slic3r --help-options
+```
 
-Most of the options accept an argument, like `--layer-height 0.2` or 
-`--perimeters 3`. Howevere there are some boolean options that work as 
+Most of the options accept an argument, like `--layer-height 0.2` or
+`--perimeters 3`. Howevere there are some boolean options that work as
 simple flags, like `--wipe` or `--avoid-crossing-perimeters`. To negate
 those options you just need to prepend `--no-` to them (as in `--no-wipe`
 or `--no-avoid-crossing-perimeters`).
 
-Some options, including the ones related to multiple extruders, accept 
+Some options, including the ones related to multiple extruders, accept
 multiple values. You can just append them multiple times:
 
-    slic3r --infill-extruder 2 --nozzle-diameter 0.35 --nozzle-diameter 0.5
+```
+slic3r --infill-extruder 2 --nozzle-diameter 0.35 --nozzle-diameter 0.5
+```
 
 **Note:** the print/filament/printer presets defined in the graphical interface
 are completely ignored when running in command line mode. Slic3r will always
@@ -107,27 +151,36 @@ In order to use your presets you'll need to export them with the *Export Config.
 command, which is located in the *File* menu. It will prompt you to save a
 `.ini` file that you can load from command line this way:
 
-    slic3r -g my_model.stl --load my_config.ini
+```
+slic3r -g my_model.stl --load my_config.ini
+```
 
 You can override single options by appending them as command line switches:
 
-    slic3r -g my_model.stl --load my_config.ini --fill-pattern concentric
+```
+slic3r -g my_model.stl --load my_config.ini --fill-pattern concentric
+```
 
 You can also create a config file from command line:
 
-    slic3r --nozzle-diameter 0.35 --filament-diameter 2.85 \
-        --temperature 185 --first-layer-temperature 195 --layer-height 0.2 \
-        --save my_config.ini
+```
+slic3r --nozzle-diameter 0.35 --filament-diameter 2.85 \
+    --temperature 185 --first-layer-temperature 195 --layer-height 0.2 \
+    --save my_config.ini
+```
 
-If you're an advanced user you can split your configuration into multiple 
+If you're an advanced user you can split your configuration into multiple
 *.ini* files and load them by appending multiple `--load` switches.
 
-The `--ignore-nonexistent-config` will prevent Slic3r from throwing an error in case a non-existent file is supplied to `--load`.
+The `--ignore-nonexistent-config` will prevent Slic3r from throwing an error in
+case a non-existent file is supplied to `--load`.
 
-One more way to use the print/filament/printer presets on command line is
+One more way to use the print/filament/printer presets on the command line is
 launching Slic3r with the `--autosave` option:
 
-    slic3r --autosave my_config.ini
+```
+slic3r --autosave my_config.ini
+```
 
 This will launch the graphical interface of Slic3r but will
 automatically export the current configuration to the specified file. Thus,
@@ -136,25 +189,25 @@ the last used presets will be remembered whenever you `--load` that file.
 ### Positioning objects in the G-code coordinates
 
 While in the graphical interface you can freely position your objects in the
-bed, command line provides two ways for telling position(s) to Slic3r:
+bed; command line provides two ways for telling position(s) to Slic3r:
 
-1. Use the `--center X,Y` option for defining a point in G-code coordinates and Slic3r will center the print around that point:
+1. Use the `--center X,Y` option for defining a point in G-code coordinates and
+   Slic3r will center the print around that point:  
+   `slic3r -g my_model.stl --center 40,40`  
+   (By default, the center point is automatically calculated as the centroid of
+   the configured print bed.)
 
-       slic3r -g my_model.stl --center 40,40
-
-   (By default, the center point is automatically calculated as the centroid of the configured print bed.)
-
-2. If you trust the coordinates of your STL file(s) and they are compatible with your
-   machine's print bed, you can use `--dont-arrange`: Slic3r will leave the input
-   locations untouched.
-   
-       slic3r -g my_model.stl --dont-arrange
+2. If you trust the coordinates of your STL file(s) and they are compatible with
+   your machine's print bed, you can use `--dont-arrange`: Slic3r will leave the
+   input locations untouched.  
+   `slic3r -g my_model.stl --dont-arrange`
 
 ### Graphical interface options
 
 * `--autosave` will automatically export the last selected config to a specified
    file (see the above paragraph about [Configuration] for its usage);
-* `--datadir` followed by the path to a directory will tell Slic3r to use that directory 
-  for storing and reading its configuration instead of the default system preferences
-  directory. (See the page about [configuration organization](/configuration-organization/configuration-organization) for more details.)
-
+* `--datadir` followed by the path to a directory will tell Slic3r to use that
+  directory for storing and reading its configuration instead of the default
+  system preferences directory. (See the page about
+  [configuration organization](/configuration-organization/configuration-organization)
+  for more details.)

--- a/src/advanced/conditional-gcode.md
+++ b/src/advanced/conditional-gcode.md
@@ -3,7 +3,8 @@
 # Overview
 
 Conditional G-code is a powerful feature of Slic3r that allows for arbitrary
-math to be done in Custom G-code fields as well as setting conditions for specific statements to appear in output from Custom G-code.
+math to be done in Custom G-code fields as well as setting conditions for
+specific statements to appear in output from Custom G-code.
 
 # Conditional expressions
 
@@ -20,21 +21,23 @@ _expression_ may take one of the following forms:
 
 _subexpression_ has the same forms as _expression_.
 
-If _subexpression_s exist, they are evaluated before any other operators.
+If *subexpression*s exist, they are evaluated before any other operators.
 
 Available operators:
 
-* `&&` or `and`: logical AND
-* `||` or `or`: logical OR
-* `!` or `not`: logical NOT (inversion)
-* `^` or `xor`: XOR (exclusive-OR)
-* `==` or `equals`: equality comparison
-* `!=`: inequality comparison. To use words, use a subexpression.
-* `<`: less than (valid for numbers only)
-* `<=`: less than or equal to (valid for numbers only)
-* `>`: greater than (valid for numbers only)
-* `>=`: greater than or equal to (valid for numbers only)
-* Anything supported by [exprtk](http://www.partow.net/programming/exprtk/index.html) (except for generic variables, file I/O and expressions that involve `{}`)
+* `&&` or `and` &ndash; logical AND
+* `||` or `or` &ndash; logical OR
+* `!` or `not` &ndash; logical NOT (inversion)
+* `^` or `xor` &ndash; XOR (exclusive-OR)
+* `==` or `equals` &ndash; equality comparison
+* `!=` &ndash; inequality comparison. To use words, use a subexpression.
+* `<` &ndash; less than (valid for numbers only)
+* `<=` &ndash; less than or equal to (valid for numbers only)
+* `>` &ndash; greater than (valid for numbers only)
+* `>=` &ndash; greater than or equal to (valid for numbers only)
+* Anything supported by
+  [exprtk](http://www.partow.net/programming/exprtk/index.html)
+  (except for generic variables, file I/O and expressions that involve `{}`)
 
 The `true` and `false` keywords are available.
 
@@ -45,8 +48,9 @@ To apply a single condition to multiple lines, repeat it once for each line:
 {if [layer_num] == 10}M600
 ````
 
-If a conditional expression evaluates to false, all the characters until the end of the line are removed.
-If a conditional expression fails to parse, it's silently left untouched.
+If a conditional expression evaluates to false, all the characters until the end
+of the line are removed. If a conditional expression fails to parse, it's
+silently left untouched.
 
 Expressions may be chained for an implicit AND:
 
@@ -56,27 +60,36 @@ Expressions may be chained for an implicit AND:
 
 ## Conventions
 
-* Numerical value of 0 is equivalent to logical `false`. Any nonzero value is considered to be logical `true`.
+* Numerical value of 0 is equivalent to logical `false`. Any nonzero value is
+  considered to be logical `true`.
     * `{if { 1 - 1 } }` would result in 0 and thus `false`.
 
 # Value expressions (G-code Math)
 
-Any expression enclosed in two curly brackets, but not starting with `{if` is evaluated as an arithmetic expression: `{foo - bar}`.
-If evaluation fails, the expression is silently left untouched.
-If any float variables are used, return value will have decimals. If string variables are mixed with numeric variables, they are parsed as floats if they have a dot, or integers otherwise.
+Any expression enclosed in two curly brackets, but not starting with `{if`,
+is evaluated as an arithmetic expression: `{foo - bar}`. If evaluation fails,
+the expression is silently left untouched. If any float variables are used,
+return value will have decimals. If string variables are mixed with numeric
+variables, they are parsed as floats if they have a dot, or integers otherwise.
 
-Value expressions can be used in conditional expressions by nesting them: `{if {foo - bar} > 10}`.
+Value expressions can be used in conditional expressions by nesting them:
+`{if {foo - bar} > 10}`.
 
-* All operators supported for conditional expressions are supported for value expressions.
+* All operators supported for conditional expressions are supported for value
+  expressions.
 
 
 # Restrictions
 
 * Every expression in `{}` must resolve to a number.
-* Nested sub-expressions are evaluated before the current expression is evaluated.
-* Value Expressions and Conditional G-code are evaluated before any post-processing scripts.
+* Nested sub-expressions are evaluated before the current expression is
+  evaluated.
+* Value Expressions and Conditional G-code are evaluated before any
+  post-processing scripts.
 
 # Troubleshooting
 
-* If the parser can't understand your statements, it will output nothing for that block.
-* Remember that Custom G-code placeholders (items in `[]`) are resolved before Conditional G-code.
+* If the parser can't understand your statements, it will output nothing for
+  that block.
+* Remember that Custom G-code placeholders (items in `[]`) are resolved before
+  Conditional G-code.

--- a/src/advanced/filament-swaps.md
+++ b/src/advanced/filament-swaps.md
@@ -1,41 +1,50 @@
 % Manual Filament Swaps with Slic3r.
 
-This page explains a useful trick to use Slic3r to use manual filament swaps in lieu of multiple extruders. 
+This page explains a useful trick to use Slic3r to use manual filament swaps in
+lieu of multiple extruders.
 
 #### Theory & Overview
 
-Slic3r has the ability to insert custom G-Code at the point of every toolchange, and this G-Code is always inserted if a tool change event occurs. 
+Slic3r has the ability to insert custom G-Code at the point of every toolchange,
+and this G-Code is always inserted if a tool change event occurs.
 
-Normally, with a single extruder you would never generate a toolchange event from Slic3r; but we can override that with modifier meshes. Also, you'll need to tell Slic3r you have more than one extruder temporarily so that you can edit the configuration.
+Normally, with a single extruder you would never generate a toolchange event from
+Slic3r; but we can override that with modifier meshes. Also, you'll need to tell
+Slic3r you have more than one extruder temporarily so that you can edit the
+configuration.
 
 #### Procedure
 
 1. Load your model into the plater.
-1. Right-click on the 
-1. Add a new modifier mesh. For this, we use the slab modifier. Any modifier will do. 
+1. Right-click on the model.
+1. Add a new modifier mesh. For this, we use the slab modifier. Any modifier
+   will do.
     * You want to enclose the entire area you want to be the new color/filament.
 ![image](images/manual-swap/generic-modifier.png)
 1. Select the modifier mesh and set the extruder to 2.
-1. Move the modifer mesh where you want to to be on the model.
+1. Move the modifer mesh where you want it to be on the model.
 1. Click "ok"
 1. Open Printer Settings.
-1. Change the number of extruders to 2. 
+1. Change the number of extruders to 2.
 ![image](images/manual-swap/extruders-2.png)
-1. Select "Custom G-Code"
-1. Scroll down to Tool-Change G-Code. 
+1. Select "Custom G-Code".
+1. Scroll down to Tool-Change G-Code.
 1. Add whatever you need to implement the filament swap here.
      * Marlin firmware has M600 available if you have an LCD for the swap.
 1. Go back to the Printer settings page.
-1. Change the number of extruders to 1. 
+1. Change the number of extruders to 1.
 ![image](images/manual-swap/extruder-1.png)
 1. Save this profile as a new profile.
 1. Download [this post processing script](https://github.com/alexrj/Slic3r/tree/master/utils/post-processing/strip-toolchange.pl)
 1. Open Print Settings.
-1. Select "Output Options"
+1. Select "Output Options".
 1. Add the path to the post processing script to the Post-Processing scripts.
-    * See [Post-Processing Scripts](/advanced/post-processing) for more information.
+    * See [Post-Processing Scripts](/advanced/post-processing) for more
+      information.
 
 
 #### Notes
 
-This technically works with anything that would cause a toolchange event; so selecting different support extruder, etc, would work the same way. More complex usages may cause a lot of swaps, so you have been warned.
+This technically works with anything that would cause a toolchange event; so
+selecting different support extruder, etc, would work the same way. More complex
+usages may cause a lot of swaps, so you have been warned.

--- a/src/advanced/flow-math.md
+++ b/src/advanced/flow-math.md
@@ -1,57 +1,96 @@
 % Flow Math
 
-This page explains the math used in Slic3r to determine the amount of flow. Documenting it serves as reference and as request for comments since better models might be worth to try.
+This page explains the math used in Slic3r to determine the amount of flow.
+Documenting it serves as reference and as request for comments since better
+models might be worth to try.
 
 #### Understanding extrusion width
 
 Two main questions affect Slic3r's work:
 
-1. **How distant** should extrusion paths be positioned in order to get a good continuous finish?
+1. **How distant** should extrusion paths be positioned in order to get a good
+   continuous finish?
 2. **How much material** must be extruded along such paths?
 
-If two adjacent paths are **too close** (or **too much material** is extruded), they'll overlap. If two adjacent paths are **too distant** (or **not enough material** is extruded), gaps will be visible and/or the extrusions will delaminate because of not enough bonding.
+If two adjacent paths are **too close** (or **too much material** is extruded),
+they'll overlap. If two adjacent paths are **too distant** (or **not enough
+material** is extruded), gaps will be visible and/or the extrusions will
+delaminate because of not enough bonding.
 
-By extruding more or less while moving (i.e. by changing the **flow speed/head speed ratio**) we can make paths thicker or thinner:
+By extruding more or less while moving (i.e. by changing the **flow speed/head
+speed ratio**) we can make paths thicker or thinner:
 
 ![image](images/flow-math/extrusion-width.png)
 
-**Thicker paths** will have **better bonding** with the lower layer, thus are good for mechanical parts. However, they'll be less able to approximate the object shape and fill tiny gaps or narrow curves (think of a drill bit: a larger one will not be able to enter narrow places). On the contrary, **thinner paths** will provide less bonding but better shape accuracy.
+**Thicker paths** will have **better bonding** with the lower layer, thus are
+good for mechanical parts. However, they'll be less able to approximate the
+object shape and fill tiny gaps or narrow curves (think of a drill bit: a larger
+one will not be able to enter narrow places). On the contrary, **thinner paths**
+will provide less bonding but better shape accuracy.
 
-However note that extrusion width can be controlled only when extruding over an existing surface (such as a previous layer or print bed). If we extrude in **free air** (i.e. when bridging), the resulting shape will be always **round** and equal to the **nozzle diameter**:
+However note that extrusion width can be controlled only when extruding over an
+existing surface (such as a previous layer or print bed). If we extrude in
+**free air** (i.e. when bridging), the resulting shape will be always **round**
+and equal to the **nozzle diameter**:
 
 ![image](images/flow-math/bridge.png)
 
-Actually, if you reduce the material flow you'll get smaller circles to some extent, until the plastic viscosity decides it's time to break your bridge because of too much tension. If, on the contrary, you extrude too much material, the shape of the extruded filament won't change (still equal to nozzle diameter) but you'll get a loose bridge.
+Actually, if you reduce the material flow you'll get smaller circles to some
+extent, until the plastic viscosity decides it's time to break your bridge
+because of too much tension. If, on the contrary, you extrude too much material,
+the shape of the extruded filament won't change (still equal to nozzle diameter)
+but you'll get a loose bridge.
 
 So, let's start from a definition:
 
-> Extrusion Width is the **thickness of a single filament** extruded either in free air or above a surface. It's **not** the distance of two adjacent paths since some overlap will be generally applied in order to get better bonding.
+> Extrusion Width is the **thickness of a single filament** extruded either in
+> free air or above a surface. It's **not** the distance of two adjacent paths
+> since some overlap will be generally applied in order to get better bonding.
 
 #### Bridges: the easy case
 
-As said above, there's only one correct flow rate for bridging: the one that doesn't make your bridge sag or break. Extrusions are **round** and their **diameter is equal to the nozzle diameter**. Parallel paths will be positioned so that they are **tangent**, thus the spacing between one path and its neighbor is equal to nozzle diameter as well. (In case of bridges, we want no overlap because it has proven to drag the existing paths.)
+As said above, there's only one correct flow rate for bridging: the one that
+doesn't make your bridge sag or break. Extrusions are **round** and their
+**diameter is equal to the nozzle diameter**. Parallel paths will be positioned
+so that they are **tangent**, thus the spacing between one path and its neighbor
+is equal to nozzle diameter as well. (In case of bridges, we want no overlap
+because it has proven to drag the existing paths.)
 
-The required material volume for a path of unitary length is calculated accordingly to the cylindric shape, thus with a circular cross-sectional area:
+The required material volume for a path of unitary length is calculated
+accordingly to the cylindric shape, thus with a circular cross-sectional area:
 
-	E = (nozzle_diameter/2)^2 * PI
+```
+E = (nozzle_diameter/2)^2 * PI
+```
 
 #### Extruding on top of a surface
 
-In this case the problem is: **what shape** will our extrusion get? We know it will get squashed horizontally, but will it have a rectangular or oval shape? What's the maximum extrusion width we can get with a given nozzle diameter before plastic starts curling at the sides?
+In this case the problem is: **what shape** will our extrusion get? We know it
+will get squashed horizontally, but will it have a rectangular or oval shape?
+What's the maximum extrusion width we can get with a given nozzle diameter
+before plastic starts curling at the sides?
 
-Slic3r assumes that the cross-sectional shape of an extrusion is a rectangle with semicircular ends. So the relationship between desired extrusion width and volume to extrude is the following:
+Slic3r assumes that the cross-sectional shape of an extrusion is a rectangle
+with semicircular ends. So the relationship between desired extrusion width and
+volume to extrude is the following:
 
 ![image](images/flow-math/area1.png)
 
-When target extrusion width is thinner than layer height the shape is unpredictable so we just use the same rectangular formula but discourage usage of such thin extrusion values.
+When target extrusion width is thinner than layer height the shape is
+unpredictable so we just use the same rectangular formula but discourage usage of
+such thin extrusion values.
 
-The above formula provides a function that correlates the target extrusion width with the amount of material to extrude per distance unit:
+The above formula provides a function that correlates the target extrusion width
+with the amount of material to extrude per distance unit:
 
-`E = f(extrusion_width, layer_height)`
+```
+E = f(extrusion_width, layer_height)
+```
 
 #### Spacing paths
 
-Okay, now we we know how much to extrude to make a single path of the desired width. But **how much should we overlap** paths in order to get perfect bonding?
+Okay, now we we know how much to extrude to make a single path of the desired
+width. But **how much should we overlap** paths in order to get perfect bonding?
 
 Supposing no overlap, thus tangent paths, there would be empty space (yellow):
 
@@ -59,23 +98,49 @@ Supposing no overlap, thus tangent paths, there would be empty space (yellow):
 
 The cross-section area of such voids is generally:
 
-`void_area = layer_height^2 - (layer_height/2)^2 * PI`
+```
+void_area = layer_height^2 - (layer_height/2)^2 * PI
+```
 
-Ideally, we would want to fill all of that yellow area by placing the extrusions closed to each other. However, it's very unlikely that the second extrusion will fill the space below the previous one, so there would still be a little void. The ideal overlap would be something like:
+Ideally, we would want to fill all of that yellow area by placing the extrusions
+closed to each other. However, it's very unlikely that the second extrusion will
+fill the space below the previous one, so there would still be a little void.
+The ideal overlap would be something like:
 
-`0 < overlap_factor*void_area < void_area`
+```
+0 < overlap_factor * void_area < void_area
+```
 
-with `overlap_factor` ranging from 0 to 1. `overlap_factor` represents how much void remains between the extrusions. It's difficult to estimate this amount, since it probably depends also on viscosity of plastic, extrusion speed and temperature. In the past, several values were tried for `overlap_factor`, but some users were still reporting too sparse paths. A value of 1 is currently being used to guarantee that the error (which is always present) is fully on the side of abundant extrusion rather than lacking material.
+with `overlap_factor` ranging from 0 to 1. `overlap_factor` represents how much
+void remains between the extrusions. It's difficult to estimate this amount,
+since it probably depends also on viscosity of plastic, extrusion speed and
+temperature. In the past, several values were tried for `overlap_factor`, but
+some users were still reporting too sparse paths. A value of 1 is currently
+being used to guarantee that the error (which is always present) is fully on
+the side of abundant extrusion rather than lacking material.
 
 Path spacing is thus:
 
-`spacing = extrusion_width - layer_height * (1 - PI/4)`
+```
+spacing = extrusion_width - layer_height * (1 - PI/4)
+```
 
 #### Sane defaults
 
-Slic3r allows users to define extrusion width manually for each kind of extrusion (perimeters, infill, support material etc.) but will calculate sane defaults if no custom values are entered.
+Slic3r allows users to define extrusion width manually for each kind of extrusion
+(perimeters, infill, support material etc.) but will calculate sane defaults if
+no custom values are entered.
 
-For the **outermost loop** of perimeters (aka *external perimeters*) Slic3r will default to a **thin extrusion width**, equal to `nozzle diameter * 1.05`. This is considered the thinnest safe extrusion width. A thin extrusion width provides **better accuracy** to the object shape and minimizes the flow errors caused by irregular filament.
+For the **outermost loop** of perimeters (aka *external perimeters*) Slic3r will
+default to a **thin extrusion width**, equal to `nozzle diameter * 1.05`. This is
+considered the thinnest safe extrusion width. A thin extrusion width provides
+**better accuracy** to the object shape and minimizes the flow errors caused by
+irregular filament.
 
-Extrusion width for other things is calculated by getting the cross-sectional area of the configured nozzle diameter and then calculating the extrusion width produced by extruding that amount of material. In other words, by **matching flow speed and head speed**. The purpose of this logic is to find the "native" flow that minimizes side forces during extrusion. Such calculated extrusion with is capped to max value equal to `nozzle_diameter * 1.7`, except for internal sparse infill where the full native flow is used.
-
+Extrusion width for other things is calculated by getting the cross-sectional
+area of the configured nozzle diameter and then calculating the extrusion width
+produced by extruding that amount of material. In other words, by **matching flow
+speed and head speed**. The purpose of this logic is to find the "native" flow
+that minimizes side forces during extrusion. Such calculated extrusion width is
+capped to max value equal to `nozzle_diameter * 1.7`, except for internal sparse
+infill where the full native flow is used.

--- a/src/advanced/modifier-mesh.md
+++ b/src/advanced/modifier-mesh.md
@@ -3,11 +3,12 @@
 # Overview
 
 Modifier meshes are one of the most advanced features of Slic3r. With them, you
-have the ability to apply distinct settings to parts of objectss. Infact Slic3r
+have the ability to apply distinct settings to parts of objects. In fact Slic3r
 allows users to define regions where the print settings should be overridden by
 distinct settings.
 
-For this example, we use this printable [ukulele](http://www.thingiverse.com/thing:199298) design. 
+For this example, we use this printable
+[ukulele](http://www.thingiverse.com/thing:199298) design.
 ![image](images/modifier-mesh/291_ukulele.jpg_large.jpg)
 
 During assembly, it was noted that string tension may break the instrument or
@@ -23,13 +24,14 @@ The joint designed was too flexible for the strains involved:
 ![image](images/modifier-mesh/300_joint.png_large.jpg)
 
 So, at this point there would have been three possible solutions:
-* redesign the parts with a larger joint (not much possible without altering the external shape of the instrument)
+* redesign the parts with a larger joint (not much possible without altering the
+  external shape of the instrument)
 * print the head with 100% solid infill
 * print just the joint area with 100% solid infill
 
 The first option is exceedingly difficult without altering the external shape
 of the instrument. Printing the entire head at 100% solid infill would work,
-but would extend the printing time and generally waste material. 
+but would extend the printing time and generally waste material.
 
 The third option permits is a "just right" solution: only the areas that
 absolutely need to be at 100% infill are printed as such. However, with normal
@@ -49,11 +51,13 @@ main part brought up the object settings menu. From there, clicking "Load
 Modifier" and selecting the previously saved model adds it to the part as a
 modifier.
 
-The green "+" was selected and "FIll Density" was added to modifier list and set to 100%.
+The green "+" was selected and "Fill Density" was added to modifier list and
+set to 100%.
 
 ![image](images/modifier-mesh/303_modifier.png_large.jpg)
 
-This is the comparison between a print with the modifier and without modifier. Note the solid area near the joint:
+This is the comparison between a print with the modifier and without modifier.
+Note the solid area near the joint:
 ![image](images/modifier-mesh/309_with.png_large.jpg)
 ![image](images/modifier-mesh/312_without.png_large.jpg)
 
@@ -73,8 +77,11 @@ To use one of the new meshes, click on the *Create Modifier* button.
 ![image](images/modifier-mesh/slic3r-create-modifier.png)
 
 There are four different volumes available:
-* Slab defines a rectangular prism with the X and Y size fixed to the size of the model being modified, with the height in Z being user-configurable. It is the easiest to work with and position. 
-* Box is another rectangular prism that you have control over all three dimensions. 
+* Slab defines a rectangular prism with the X and Y size fixed to the size of
+  the model being modified, with the height in Z being user-configurable. It is
+  the easiest to work with and position.
+* Box is another rectangular prism that gives you control over all three
+  dimensions.
 * Cylinder gives you control over the radius of a circle and the height.
 * Sphere has one attribute: the radius of the sphere.
 

--- a/src/advanced/placeholder-parser.md
+++ b/src/advanced/placeholder-parser.md
@@ -2,46 +2,53 @@
 
 # Overview
 
-Slic3r supports a variety of placeholders from settings and some internal values for use in Custom GCode.
+Slic3r supports a variety of placeholders from settings and some internal values
+for use in Custom G-Code.
 
 # All situations
 
 * Any configuration setting.
-    * For easy reference, export your current print configuration to an .ini file and open it with a text editor. 
-* `[input_filename]` - Input filename
-* `[input_filename_base]` - Input filename with extension stripped
+    * For easy reference, export your current print configuration to an .ini
+      file and open it with a text editor.
+* `[input_filename]` &ndash; Input filename
+* `[input_filename_base]` &ndash; Input filename with extension stripped
     * object.stl -> object
-* `[timestamp]` - Current date/time
-    * Each component from the timestamp is available: [year], [month], [day], [hour], [minute], [second]
+* `[timestamp]` &ndash; Current date/time
+    * Each component from the timestamp is available: [year], [month], [day],
+      [hour], [minute], [second]
 * `[scale]`
-   * `[scale_0]`, `[scale_1]`, ... for specific scales
-* `[print_preset]` - name of the current print preset. Only available when using plater GUI.
-* `[filament_preset]` - name of the current filament preset. Only available when using plater GUI.
-* `[printer_preset]` - name of the current printer preset. Only available when using plater GUI.
-* `[layer_z]` - Z height of the active layer.
+   * `[scale_0]`, `[scale_1]`, … for specific scales
+* `[print_preset]` &ndash; name of the current print preset. Only available when
+  using plater GUI.
+* `[filament_preset]` &ndash; name of the current filament preset. Only available
+  when using plater GUI.
+* `[printer_preset]` &ndash; name of the current printer preset. Only available
+  when using plater GUI.
+* `[layer_z]` &ndash; Z height of the active layer.
     * Automatically set by Slic3r.
-* `[layer_num]` - Integer number of the active layer.
+* `[layer_num]` &ndash; Integer number of the active layer.
     * Automatically set by Slic3r.
-* `[current_extruder]` - Currently selected extruder.
+* `[current_extruder]` &ndash; Currently selected extruder.
     * Automatically set by Slic3r.
 
 Note: Multi-value options can be called with indices, like `[nozzle_diameter_1]`.
 
-# Filament Start/End GCode
-The following items are available only for Filament Start/End GCode.
+# Filament Start/End G-Code
+The following items are available only for Filament Start/End G-Code.
 
 * `[filament_extruder_id]`
-    * Value of this setting is the current extruder this filament profile is loaded.
+    * Value of this setting is the current extruder this filament profile is
+      loaded.
     * Automatically set by Slic3r.
 
-# Before/After Layer Change GCode
+# Before/After Layer Change G-Code
 
-* `[current_retraction]` - Amount retracted for the current extruder.
+* `[current_retraction]` &ndash; Amount retracted for the current extruder.
     * Automatically set by Slic3r.
 
-# Toolchange GCode
+# Toolchange G-Code
 
-The following items are available only during Toolchange Custom GCode.
+The following items are available only during Toolchange Custom G-Code.
 
 * `[next_extruder]`
     * Automatically set by Slic3r.

--- a/src/advanced/plater.md
+++ b/src/advanced/plater.md
@@ -2,35 +2,38 @@
 Plater Features
 ---------------
 
-Slic3r's plater is powerful and contains many useful options. 
+Slic3r's plater is powerful and contains many useful options.
 
 
 ### View Menu
 
-The View menu in Slic3r contains a few commands and one configurable preference/option. 
- ![View menu](images/plater/view-menu.png "fig:") 
+The View menu in Slic3r contains a few commands and one configurable preference/option.
+ ![View menu](images/plater/view-menu.png "fig:")
 
-- Top (Ctrl+4): Immediately rotate the plater to a top-down view.
- ![View top](images/plater/view-top.png "fig:") 
-- Bottom (Ctrl+5): Immediately rotate the plater to a bottom-up view.
- ![View bottom](images/plater/view-bottom.png "fig:") 
-- Left (Ctrl+6): Immediately rotate the plater to a profile view of the left side of the plater.
- ![View left](images/plater/view-left.png "fig:") 
-- Right (Ctrl+7): Immediately rotate the plater to a profile view of the right side of the plater.
- ![View right](images/plater/view-right.png "fig:") 
-- Front (Ctrl+8): Immediately rotate the plater to a profile view of the front side of the plater.
- ![View front](images/plater/view-front.png "fig:") 
-- Back (Ctrl+9): Immediately rotate the plater to a profile view of the diagonal side of the plater.
- ![View back](images/plater/view-back.png "fig:") 
+- Top (Ctrl+4) &ndash; Immediately rotate the plater to a top-down view.
+ ![View top](images/plater/view-top.png "fig:")
+- Bottom (Ctrl+5) &ndash; Immediately rotate the plater to a bottom-up view.
+ ![View bottom](images/plater/view-bottom.png "fig:")
+- Left (Ctrl+6) &ndash; Immediately rotate the plater to a profile view of the
+  left side of the plater.
+ ![View left](images/plater/view-left.png "fig:")
+- Right (Ctrl+7) &ndash; Immediately rotate the plater to a profile view of the
+  right side of the plater.
+ ![View right](images/plater/view-right.png "fig:")
+- Front (Ctrl+8) &ndash; Immediately rotate the plater to a profile view of the
+  front side of the plater.
+ ![View front](images/plater/view-front.png "fig:")
+- Back (Ctrl+9) &ndash; Immediately rotate the plater to a profile view of the
+  back side of the plater.
+ ![View back](images/plater/view-back.png "fig:")
 - Diagonal (Ctrl+0): Immediately reset the plater to the initial view.
- ![View diagonal](images/plater/view-diagonal.png "fig:") 
+ ![View diagonal](images/plater/view-diagonal.png "fig:")
 
 There are two ways to view the coloration in the 3D preview:
 - Color Toolpaths by Role
-    - This mode uses the regular Slic3r color scheme to pick the colors (default, Solarized, etc). 
- ![View color by role](images/plater/view-color-role.png "fig:") 
+    - This mode uses the regular Slic3r color scheme to pick the colors
+      (default, Solarized, etc).
+ ![View color by role](images/plater/view-color-role.png "fig:")
 - Color Toolpaths by Filament
-    - This mode uses the specified colors from the selected Material profiles. 
- ![View color by role](images/plater/view-color-filament.png "fig:") 
-
-
+    - This mode uses the specified colors from the selected Material profiles.
+ ![View color by role](images/plater/view-color-filament.png "fig:")

--- a/src/advanced/post-processing.md
+++ b/src/advanced/post-processing.md
@@ -5,11 +5,12 @@ or modified after it has been created. For this reason there exists the
 ability to run arbitrary scripts as part of the final steps in the
 slicing process.
 
-Example scripts can be found in the [GitHub repository](https://github.com/alexrj/Slic3r/tree/master/utils/post-processing)
+Example scripts can be found in the
+[GitHub repository](https://github.com/alexrj/Slic3r/tree/master/utils/post-processing)
 or in the [RepRap forum](http://forums.reprap.org/list.php?263).
 
 **Note:** post-processing scripts can be written in **any language**
-(Perl, Python, Ruby, Bash etc.). They just need to be executable and to 
+(Perl, Python, Ruby, Bash etc.). They just need to be executable and to
 accept the path to the G-code file as the only argument.
 
 In the `Output options` section of the `Print Settings` tab lies the
@@ -30,10 +31,11 @@ the scripts by way of environment variables. These all begin with
 leave the G-code unmodified and just write out all Slic3r options to standard
 output:
 
-    #!/bin/sh
-    echo "Post-processing G-code file: $*"
-    env | grep ^SLIC3R
-
+```
+#!/bin/sh
+echo "Post-processing G-code file: $*"
+env | grep ^SLIC3R
+```
 
 #### Post-Processing Script Parameters
 
@@ -41,15 +43,21 @@ You can use parameters with your script as such:
 
 Examples:
 
-`/path/to/executable` becomes `/path/to/executable` with the arg `outputfilename.gcode`
+- `/path/to/executable` becomes `/path/to/executable` with the arg
+  `outputfilename.gcode`
 
-`/path/to/executable -arg -arg2` becomes `/path/to/executable` with `args -arg, -arg2`, and `outputfilename.gcode`
+- `/path/to/executable -arg -arg2` becomes `/path/to/executable` with
+  `args -arg, -arg2`, and `outputfilename.gcode`
 
-`/path/to/executable! with! spaces -arg -arg2` becomes `/path/to/executable with spaces with args -arg, -arg2`, and `outputfilename.gcode`
+- `/path/to/executable! with! spaces -arg -arg2` becomes
+  `/path/to/executable with spaces with args -arg, -arg2`, and
+  `outputfilename.gcode`
 
-`/path/to/executable!! -arg -arg2` becomes `/path/to/executable!` with `args -arg, -arg2`, and `outputfilename.gcode`
+- `/path/to/executable!! -arg -arg2` becomes `/path/to/executable!` with
+  `args -arg, -arg2`, and `outputfilename.gcode`
 
-`/path/to/executable option! with! spaces` becomes `/path/to/executable` with args `option with spaces` and `outputfilename.gcode`
+- `/path/to/executable option! with! spaces` becomes `/path/to/executable`
+  with args `option with spaces` and `outputfilename.gcode`
 
 
 Perl example
@@ -60,40 +68,50 @@ the G-Code file, without having to copy, edit, then replace the
 original. The following example will simply output the contents to
 standard output:
 
-    #!/usr/bin/perl -i
-    use strict;
-    use warnings;
+```
+#!/usr/bin/perl -i
+use strict;
+use warnings;
 
-    while (<>) {
-         # modify $_ here before printing
-         print;
-    }
+while (<>) {
+     # modify $_ here before printing
+     print;
+}
+```
 
 If you are getting a *can't do inplace edit without backup* error when specifying
-the post-process script, try adding `$^I = '.bak';` before the while loop. This will
-create a backup file of the generated G-Code file. Windows does not like to have two
-scripts creating and/or accessing a single file at once, so a backup is needed.
+the post-process script, try adding `$^I = '.bak';` before the while loop. This
+will create a backup file of the generated G-Code file. Windows does not like to
+have two scripts creating and/or accessing a single file at once, so a backup is
+needed.
 
 
 Python example
 --------------
 
 #### Windows
-To use a Python post-processing script with Windows, you'll need to adjust the paths like this:
+To use a Python post-processing script with Windows, you'll need to adjust the
+paths like this:
 
-    C:\Program! Files! (x86)\Python37-32\python.exe c:\dev\SCPP\Slic3rConfigPrettyPrint.py -o --au "John Doe"
+```
+C:\Program! Files! (x86)\Python37-32\python.exe c:\dev\SCPP\Slic3rConfigPrettyPrint.py -o --au "John Doe"
+```
 
-Note the **!** before all white-spaces! Make sure you adjust the path to your script as well.
-Yes, you can save your G-Code file to somewhere with spaces in it's path.
+Note the **!** before all white-spaces! Make sure you adjust the path to your
+script as well. Yes, you can save your G-Code file to somewhere with spaces in
+it's path.
 
-Your script needs to accept at least one parameter: The filename of your G-Code file.
-`-o` and `--au "John Doe"` are optional parameters. The filename, of your G-Code, will be added to the end of this string.
+Your script needs to accept at least one parameter: The filename of your G-Code
+file. `-o` and `--au "John Doe"` are optional parameters. The filename, of your
+G-Code, will be added to the end of this string.
 
 Python.exe will then run your script with the specified parameters.
 
 This `example.py` will just output the filename submitted by Slic3r:
 
-    import sys
-    print ('This is the name of your G-Code file: {0}'.format(sys.argv[1]))
+```
+import sys
+print ('This is the name of your G-Code file: {0}'.format(sys.argv[1]))
+```
 
-`sys.argv[0]` is the script `example.py`.
+`sys.argv[0]` is the name of the script, `example.py`.

--- a/src/advanced/repairing-models.md
+++ b/src/advanced/repairing-models.md
@@ -9,10 +9,10 @@ the ones described here are all free at the time of writing.
 
 #### Netfabb Studio
 
- Netfabb produce a range of 3D modelling
+Netfabb produce a range of 3D modelling
 applications, including a free basic version[^1]. This version includes
 a mesh repair module which can help eliminate the various problems
-faced. Up-to-date instructions can be found on the Netfabb wiki[^2], the
+faced. Up-to-date instructions can be found on the Netfabb wiki[^2]; the
 following is a quick overview of the steps involved.
 
  ![Netfabb Studio: Part
@@ -26,11 +26,11 @@ repair.](images/repair/netfabb_studio_part_repair.png "fig:")
 
 -   To run the repair scripts, select the part and then either click the
     first aid icon in the toolbar (the red cross), or select from the
-    context menu `Extras->Repair Part`. This will open the part repair
+    context menu `Extras` -> `Repair Part`. This will open the part repair
     tab and show the status of the model.
 
 -   The `Actions` and the `Repair scripts` tabs offer several repair
-    scripts which can be applied manually, however for the purposes of
+    scripts, which can be applied manually. However for the purposes of
     this overview selecting the `Automatic repair` script will fix most
     problems.
 
@@ -42,7 +42,7 @@ repair.](images/repair/netfabb_studio_part_repair.png "fig:")
     `Apply repair`, choosing whether to override the existing part or
     not.
 
--   The part may then be exported by selecting `Export part->As STL`
+-   The part may then be exported by selecting `Export part` -> `As STL`
     from the context menu.
 
 -   If Netfabb still detects that the exported part will still contain
@@ -51,11 +51,11 @@ repair.](images/repair/netfabb_studio_part_repair.png "fig:")
 
      ![Netfabb Studio: Part
     export.](images/repair/netfabb_studio_export_part.png "fig:")
-    
+
 
 #### Netfabb Cloud Service
 
- Netfabb also hosts a web service where an
+Netfabb also hosts a web service where an
 STL file may be uploaded for it to be checked and repaired[^3].
 
  ![Netfabb Cloud
@@ -66,22 +66,18 @@ Services.](images/repair/netfabb_cloud_services.png "fig:")
 
 -   Choose the STL file to upload using the button provided.
 
--   An email address must be given to inform you when the service is
-    finished.
+-   An email address must be given to inform you when the service is finished.
 
 -   Choose whether metric or imperial measurements should be used.
 
--   Read and accept the terms of service, and then click
-    `Upload to Cloud`.
+-   Read and accept the terms of service, and then click `Upload to Cloud`.
 
 -   Once the service has analysed and repaired the file an email is sent
     providing the download link to the repaired file.
 
 #### FreeCAD
 
-
-
-Freecad[^4] is a comprehensive, and free, CAD program which comes with a
+Freecad[^4] is a comprehensive, and free, CAD program that comes with a
 mesh module, in which repairs to degenerate models can be made. the
 following steps outline how a problem model file can be analysed and
 repaired.
@@ -90,18 +86,17 @@ repaired.
 repair.](images/repair/freecad_part_repair.png "fig:")
 
 
--   Start FreeCAD and from the start splash page choose
-    `Working with Meshes`.
+-   Start FreeCAD and from the start splash page choose `Working with Meshes`.
 
 -   Load the model by dragging and dropping it onto the workspace or via
     the `File` menu. A small message in the bottom left corner will
     indicate if the model appears to have problems.
 
--   From the menu choose `Meshes->Analyze->Evaluate & Repair mesh` to
+-   From the menu choose `Meshes` -> `Analyze` -> `Evaluate & Repair mesh` to
     bring up the repair options dialog.
 
 -   From the options dialog choose the loaded mesh, then perform each
-    analysis be clicking the `Analyze` button by each problem type, or
+    analysis by clicking the `Analyze` button by each problem type, or
     select `Repetitive Repair` at the bottom to perform all checks. If a
     corresponding problem is detected the `Repair` button becomes
     enabled.
@@ -110,10 +105,9 @@ repair.](images/repair/freecad_part_repair.png "fig:")
 
 -   It is important to review the effect the repair script has made to
     the model. It may be the case that the script damages the file,
-    rather than repair, for example by removing important triangles.
+    rather than repairit, for example by removing important triangles.
 
--   Export the repaired model via the `Export` menu option or context
-    menu.
+-   Export the repaired model via the `Export` menu option or context menu.
 
 [^1]: http://www.netfabb.com/basic.php
 

--- a/src/advanced/sequential-printing.md
+++ b/src/advanced/sequential-printing.md
@@ -3,7 +3,7 @@
 When printing several objects at once it can be useful to print each one
 separately as this will minimise oozing and strings running between the
 prints. It will also decrease the risk of a problem ruining the entire
-print - if one part detaches or fails in some way, it will not be
+print &mdash; if one part detaches or fails in some way, it will not be
 dragged into other parts of the print during each layer.
 
  ![Sequential printing
@@ -17,11 +17,11 @@ or extruder will collide with a part, but double check that the layout
 of the parts will not cause problems. The `Extruder clearance`
 parameters help Slic3r detect potential collisions:
 
--   `Radius` - The clearance that should be given around the extruder.
-    Take care if the extruder is not mounted centrally - take the
+-   `Radius` &ndash; The clearance that should be given around the extruder.
+    Take care if the extruder is not mounted centrally &mdash; take the
     largest safe value.
 
--   `Height` - The vertical distance between the nozzle tip and the X
+-   `Height` &ndash; The vertical distance between the nozzle tip and the X
     axis rods, or lowest part which may interfere with a finished print.
 
  ![The clearance cylinder around an
@@ -34,9 +34,10 @@ shortest to tallest). In the majority of cases, this behavior minimizes issues
 with height clearance around the extruder. In specific use cases, one may wish
 to manually order sequentially printed objects. This may be achieved by modifying
 the optional sequential-print-priority parameter (default: 0) for each object.
-This option may be accessed either by double-clicking on the object in the 3D plater
-view or by selecting the object and clicking on the "Settings" button in the toolbar.
-Objects assigned the same print priority are sorted in order of height.
+This option may be accessed either by double-clicking on the object in the 3D
+plater view or by selecting the object and clicking on the "Settings" button in
+the toolbar. Objects assigned the same print priority are sorted in order of
+height.
 
  ![Sequential print order
 options.](images/sequential_printing_order.png "fig:")

--- a/src/advanced/svg-output.md
+++ b/src/advanced/svg-output.md
@@ -1,9 +1,9 @@
 % SVG Output
 
-Slic3r can produce output for other types of 3D printers which require
+Slic3r can produce output for other types of 3D printers that require
 each layer to be represented as image, for example DLP resin or
 powder-bed printers. These expect an image usually consisting of a white
-silhouette on a black background (See fig ).
+silhouette on a black background. (See the figure below.)
 Almost all image formats can be used (bmp, png, etc.), however, because
 the image may have to be scaled, it is usually desirable to use a vector
 format, rather than a bitmap format. For this reason it is common to use
@@ -24,9 +24,8 @@ Attempting to view the SVG file in a browser will result in only the
 first layer being shown, and only the negative islands within the model
 (as the browser background is usually white).
 
- ![SVG in the
+![SVG in the
 browser.](images/svg_output/svg_direct_browser.png "fig:")
-
 
 For this reason a small web application was written to allow each slice
 to be displayed, and for it to be shown on a black background[^1].
@@ -36,11 +35,11 @@ screen to have it load and display.
  ![Slic3r SVG
 Viewer.](images/svg_output/svg_slic3rsvg_viewer.png "fig:")
 
+Other open-source tools, such as [Inkscape](https://inkscape.org/) will also
+allow viewing of SVG files.
 
 SVG Settings
 ------------
-
-
 
 The majority of options in Slic3r are not required when generating SVG,
 however the `Layer height` setting will dictate the number of layers.
@@ -50,8 +49,6 @@ desired.
 
 Printing with SVG
 -----------------
-
-
 
 Whilst SVG output can be used in a range of printers, the following
 example shows how the file can be used with a DLP resin printer. Using a

--- a/src/configuration-organization/configuration-organization.md
+++ b/src/configuration-organization/configuration-organization.md
@@ -5,9 +5,14 @@ Profiles
 
 Configuration in Slic3r is organized across three categories:
 
-* **Printer Settings**: these options define capabilities of the printer(s). You rarely need to change these option after the initial setup of a new printer.
-* **Filament Settings**: these options define filament-specific properties, such as diameter, temperatures and cooling.
-* **Print Settings**: these options define the "build styles" that you can use for each print. For example you might want to have distinct profiles for vases, mechanical objects, high quality models, drafts and so on.
+* **Printer Settings** &ndash; these options define capabilities of the
+  printer(s). You rarely need to change these option after the initial setup of
+  a new printer.
+* **Filament Settings** &ndash; these options define filament-specific
+  properties, such as diameter, temperatures and cooling.
+* **Print Settings** &ndash; these options define the "build styles" that you can
+  use for each print. For example you might want to have distinct profiles for
+  vases, mechanical objects, high quality models, drafts and so on.
 
 From the main view (the plater) you can quickly select the profiles you want to use for printing: a printer, a filament and a print style.
 
@@ -29,26 +34,50 @@ the red delete button next to the save button.
 Exporting and Importing
 =======================
 
-If you want to transfer your settings to another computer, or send them via e-mail, or store them along with your models, you can use the `Export Config...` command in the File menu. This will save all the values of the currently selected presets into a text file having a `.ini` extension. These files can be easily loaded back with the `Load Config...` command.
+If you want to transfer your settings to another computer, or send them via
+e-mail, or store them along with your models, you can use the `Export Config...`
+command in the File menu. This will save all the values of the currently
+selected presets into a text file having a `.ini` extension. These files can be
+easily loaded back with the `Load Config...` command.
 
-Note that loading a config file doesn't store it as a preset automatically, so it will be not remembered the next time you launch Slic3r. If you want to store it you'll have to go through the *Print Settings*, *Filament Settings* and *Printer Settings* sections and hit the "Save" button for each section you want to create a preset in.
+Note that loading a config file doesn't store it as a preset automatically, so it
+will be not remembered the next time you launch Slic3r. If you want to store it
+you'll have to go through the *Print Settings*, *Filament Settings* and *Printer
+Settings* sections and hit the "Save" button for each section you want to create
+a preset in.
 
-The `Export Config Bundle...` allows to export the **entire** set of profiles to a single file (not just the selected profiles). This is handy if you want to clone a Slic3r setup from one computer to another, or make a backup.
+The `Export Config Bundle...` allows the user to export the **entire** set of
+profiles to a single file (not just the selected profiles). This is handy if you
+want to clone a Slic3r setup from one computer to another, or make a backup.
 
-Import Configuration from GCode
+Import Configuration from G-Code
 -------------------------------
 
-If you want to use the same settings/configuration from model B in your model A, you can do so by simply importing the GCode-file from model B.
-In `File` choose `Import Config from GCode-File...` and select your previously saved GCode (model B) file.
+If you want to use the same settings/configuration from model B in your model A,
+you can do so by simply importing the G-Code-file from model B. In `File` choose
+`Import Config from GCode-File...` and select your previously saved GCode (model
+B) file.
 
-When you click `OK` on your model B, a new `.ini` file will be created in the same directory as your model B. It's named just like your model B: `<name-of-model-B>.ini`. After the file has been created, it will automatically be imported in Slic3r. This `.ini` file holds your settings and could also be shared with others without revealing your CGode.
+When you click `OK` on your model B, a new `.ini` file will be created in the
+same directory as your model B. It's named just like your model B:
+`<name-of-model-B>.ini`. After the file has been created, it will automatically
+be imported in Slic3r. This `.ini` file holds your settings and could also be
+shared with others without revealing your C-Gode.
 
-Note that this only works for GCode files which were sliced using Slic3r. Also, these settings are not stored in Slic3r.
+Note that this only works for G-Code files which were sliced using Slic3r. Also,
+these settings are not stored in Slic3r unless you explicity create profiles for
+them.
 
 Using a Custom Data Directory
 =============================
 
-By default, Slic3r stores its settings and profiles into a system directory, which depends on the operating system. Users are not supposed to touch such application preferences directories, so they're chosen automatically. However, Slic3r has a `--datadir` command line option that allows to use a custom directory. This can be useful for several customizations, such as keeping multiple Slic3r copies on a single computer, or for sharing configuration files across network.
+By default, Slic3r stores its settings and profiles into a system directory,
+which depends on the operating system. Users are not supposed to touch such
+application preferences directories, so they're chosen automatically. However,
+Slic3r has a `--datadir` command line option that allows the user to set a custom
+directory. This can be useful for several customizations, such as keeping
+multiple Slic3r copies on a single computer, or for sharing configuration files
+across network.
 
 Sharing Configuration across Network
 ------------------------------------
@@ -59,7 +88,11 @@ If you have a network-mounted device you can simply launch Slic3r with the `--da
 slic3r.exe --datadir Z:\Slic3r-settings
 ```
 
-On Linux and MacOS X you have another option instead of using `--datadir`: a link to the shared directory can be created where Slic3r looks for the default directory. This can used for example for synchronizing Slic3r presets using Dropbox. The first step is to find the path where Slic3r looks for its configuration:
+On Linux and MacOS X you have another option instead of using `--datadir`: a
+link to the shared directory can be created where Slic3r looks for the default
+directory. This can used for example for synchronizing Slic3r presets using
+Dropbox. The first step is to find the path where Slic3r looks for its
+configuration:
 
 ```
 $ /Applications/Slic3r.app/Contents/MacOS/slic3r --debug
@@ -73,7 +106,8 @@ Now, after closing Slic3r, we move this directory to our shared folder:
 mv "/Users/al/Library/Application Support/Slic3r" ~/Dropbox/Slic3r-settings
 ```
 
-(Double quotes are needed because of the space in the path, but if you're doing this you should already know how to work with the terminal.)
+(Double quotes are needed because of the space in the path, but if you're doing
+this you should already know how to work with the terminal.)
 
 And finally we create a symbolic link:
 
@@ -87,8 +121,10 @@ Using another Color-Scheme
 Simple Usage
 ------------
 
-To use another color scheme, you can switch from the default to Solarized (by Ethan Schoonover: http://ethanschoonover.com/solarized).
-Go to `File` -> `Preferences` -> `Color Scheme` and choose `Solarized` (or change back to the default colors). Click `OK` and restart Slic3r.
+To use another color scheme, you can switch from the default to Solarized
+(by Ethan Schoonover: http://ethanschoonover.com/solarized). Go to `File`
+-> `Preferences` -> `Color Scheme` and choose `Solarized` (or change back
+to the default colors). Click `OK` and restart Slic3r.
 
 All viewport colors have been changed to a reduced brighness contrast.
 
@@ -105,4 +141,6 @@ All viewport colors have been changed to a reduced brighness contrast.
 Advanced Usage
 --------------
 
-Take a look at the files `./lib/Slic3r/GUI/ColorScheme.pm` and `./lib/Slic3r/GUI/Preferences.pm` in the `colorscheme`-section for comments on how to create your own color-scheme or to change the colors.
+Take a look at the files `./lib/Slic3r/GUI/ColorScheme.pm` and
+`./lib/Slic3r/GUI/Preferences.pm` in the `colorscheme`-section for comments on
+how to create your own color-scheme or to change the colors.

--- a/src/expert-mode/cooling.md
+++ b/src/expert-mode/cooling.md
@@ -16,8 +16,8 @@ Figure shows the strategy adopted by Slic3r.
 Reading from right to left, when the minimum fan threshold (#2) is
 reached the fan is turned on. This increases in intensity as the layer
 time decreases. The print speed remains constant until the estimated
-print time drops below a certain threshold (#1), this is when the print
-speed is reduced until it reaches it’s minimum value.
+print time drops below a certain threshold (#1); this is when the print
+speed is reduced until it reaches its minimum value.
 
 Fans
 ----
@@ -53,35 +53,34 @@ Configuring
 ![Cooling settings.](images/cooling_advanced_settings.png)
 
 
--   `Keep fan always on` - If this is enabled, fan will never be disabled 
+-   `Keep fan always on` &ndash; If this is enabled, fan will never be disabled
      and will be kept running at least at its minimum speed. Useful for PLA,
      harmful for ABS.
 
--   `Enable auto cooling` - This enables/disables the cooling logic. A 
-    descriptive text below this option describes the effects of the 
+-   `Enable auto cooling` &ndash; This enables/disables the cooling logic. A
+    descriptive text below this option describes the effects of the
     current configuration.
 
--   `Fan speed` - Determines the minimum and maximum speeds - useful for
-    fans that run too fast by default.
+-   `Fan speed` &ndash; Determines the minimum and maximum speeds &mdash; useful
+    for fans that run too fast by default.
 
--   `Bridges fan speed` - As the material stretches over wide gaps, it
-    makes sense to try and cool it as much as possible, therefore a full
+-   `Bridges fan speed` &ndash; As the material stretches over wide gaps, it
+    makes sense to try and cool it as much as possible; therefore a full
     fan speed is recommended.
 
--   `Disable fan for first n layers` - Section
-     detailed how important the first
-    layer is, and so it makes sense not to apply the fan until sure the
-    print is securely attached to the bed. Keeping the fan turned off
-    for the first two or three layers is a good idea.
+-   `Disable fan for first n layers` &ndash; Section
+    [The Important First Layer](#../first-print/first-layer) detailed how
+    important the first layer is, and so it makes sense not to apply the fan
+    until sure the print is securely attached to the bed. Keeping the fan
+    turned off for the first two or three layers is a good idea.
 
--   `Enable fan if print time is below t seconds` - Triggers the fan if
+-   `Enable fan if print time is below t seconds` &ndash; Triggers the fan if
     the layer will be completed within the given number of seconds.
 
--   `Slow down if layer print time is below t seconds` - Slows down the
-    print if the layer will be completed within the given number of
-    seconds.
+-   `Slow down if layer print time is below t seconds` &ndash; Slows down the
+    print if the layer will be completed within the given number of seconds.
 
--   `Min print speed` - A lower limit on how slowly a layer can be
+-   `Min print speed` &ndash; A lower limit on how slowly a layer can be
     printed.
 
 

--- a/src/expert-mode/fighting-ooze.md
+++ b/src/expert-mode/fighting-ooze.md
@@ -2,7 +2,7 @@
 
 Unless the material being extruded has a very high viscosity it will
 ooze from the nozzle in between extrusions. There are several settings
-in Slic3r to which can help to remedy this.
+in Slic3r that can help to remedy this.
 
 The retraction settings, found in the `Extruder` section of `Printer` tab,
 tell the printer to pull back the filament between extrusion moves. This
@@ -13,75 +13,75 @@ for the next extrusion.
  ![Retraction settings.](images/retraction_settings.png "fig:")
 
 
--   `Length` - The number of millimeters to retract. Note that the
+-   `Length` &ndash; The number of millimeters to retract. Note that the
     measurement is taken from the raw filament entering the extruder. A
     value of between 1 and 2mm is usually recommended. Bowden extruders
     may need up to 4 or 5mm due to the hysteresis introduced by the
     tube.
 
--   `Lift Z` - Raises the entire extruder on the Z axis by that many
+-   `Lift Z` &ndash; Raises the entire extruder on the Z axis by that many
     millimeters during each travel. This can be useful to ensure the
     nozzle will not catch on any already laid filament, however it is
     usually not necessary and will slow the print speed. A value of
     0.1mm is usually sufficient.
 
--   `Speed` - The speed at which the extruder motor will pull back the
+-   `Speed` &ndash; The speed at which the extruder motor will pull back the
     filament. The value should be set to as quick as the extruder can
     handle without skipping steps, and it is worth experimenting with
     this value to find the quickest retraction possible.
 
--   `Extra length on restart` - Adds an extra length of filament after
+-   `Extra length on restart` &ndash; Adds an extra length of filament after
     the retraction is compensated after the travel move. This setting is
     rarely used, however should the print show signs of not having
     enough material after travel moves then it may be useful to add a
     small amount of additional material.
 
--   `Minimum travel after retraction` - Triggering a retraction after
+-   `Minimum travel after retraction` &ndash; Triggering a retraction after
     very short moves is usually unnecessary as the amount of ooze is
     usually insignificant and it slows down the print times. Set the
     number of millimeters minimum distance the nozzle must move before
     considering a retraction. If the printer handles ooze well this can
     be increased to 5 or 6mm.
 
--   `Retract on layer change` - Movement along the Z axis must also be
+-   `Retract on layer change` &ndash; Movement along the Z axis must also be
     considered when dealing with oozing, otherwise blobs may occur. It
     is recommended to leave this setting on.
 
--   `Wipe before retract` - Moves the nozzle whilst retracting so as to
+-   `Wipe before retract` &ndash; Moves the nozzle whilst retracting so as to
     reduce the chances of a blob forming.
 
-Additionally there are several settings in the `Print` tab which can
+Additionally there are several settings in the `Print` tab that can
 help control oozing.
 
--   `Only retract when crossing perimeters` (Infill) - Tells Slic3r to
+-   `Only retract when crossing perimeters` (Infill) &ndash; Tells Slic3r to
     only retract if the nozzle will cross the threshold of the current
     island being extruded. Slight ooze within the walls of a part are
     not seen and can usually be accepted.
 
--   `Avoid crossing perimeters` (Layers and perimeters - Advanced) -
+-   `Avoid crossing perimeters` (Layers and perimeters &mdash; Advanced) &ndash;
     Will force the nozzle to follow perimeters as much as possible to
     minimise the number of times it must cross them when moving around,
     and between, islands. This has a negative impact on both G-code
     generation and print times.
 
--   `Seam position` (Layers and perimeters - Vertical shells) - This 
+-   `Seam position` (Layers and perimeters &mdash; Vertical shells) &ndash; This
     setting determines the start point of perimeter loops, and thus the
     position of the potentially visible vertical seam on the side of the
     object. The available options are:
-    * `Random` - This will choose a different point for each layer, thus
+    * `Random` &ndash; This will choose a different point for each layer, thus
         making the seam less noticeable.
-    * `Nearest` - This will try to choose a concave non-overhang vertex
-        so that the seam is hidden in the inside of the concave angle. 
+    * `Nearest` &ndash; This will try to choose a concave non-overhang vertex
+        so that the seam is hidden in the inside of the concave angle.
         If no concave non-overhang vertices are available, it will choose
-        a convex non-overhang vertex. If none are available, it will 
+        a convex non-overhang vertex. If none are available, it will
         choose a non-overhang vertex. The choice among the candidates is
         operated so that the start point is the nearest to the previous
         extruder position. So this option will optimize for short travels.
-    * `Aligned` - This will use the same logic as `Nearest` for finding the
-        candidates, but it will choose the one that is nearest to the 
+    * `Aligned` &ndash; This will use the same logic as `Nearest` for finding the
+        candidates, but it will choose the one that is nearest to the
         start point of the previous layer. This will ensure the seam is
         mostly aligned throughout the whole object.
-        
+
 
 See also section : Sequential Printing
 for another technique which can minimise strings forming between

--- a/src/expert-mode/filament-settings.md
+++ b/src/expert-mode/filament-settings.md
@@ -12,7 +12,7 @@ Settings.](images/filament_settings_1.png "fig:")
 
 #### Filament.
 
- The `Diameter` setting will already have been filled from
+The `Diameter` setting will already have been filled from
 the value given during the wizard (see p.), but can be updated here.
 
 The `Extrusion multiplier` setting allows the fine tuning of the
@@ -25,9 +25,9 @@ visible.
 
 #### Temperature.
 
- These values are also filled from the wizard, but here
+These values are also filled from the wizard, but here
 the opportunity exists to set the temperature for the first layer (see
-p.).
+[The Important First Layer](#../first-print/first-layer)).
 
 #### Optional Information
 
@@ -39,9 +39,10 @@ to aid in projected weight and cost calculations.
 
 Custom G-code can be added on a per-filament basis, exactly as in Printer
 Settings.  Filament custom start G-code is always executed after the printer
-start gcode and the end gcode is executed before printer end gcode.
+start gcode and the end G-code is executed before printer end G-code.
 
 #### Overrides
 
 - `Max volumetric speed` overrides the value given in Printer Settings. See that topic for more informaition.
 - `Compatible Printers` works the same as the option in Printer Settings. Set that topic for more information.
+

--- a/src/expert-mode/multiple-extruders.md
+++ b/src/expert-mode/multiple-extruders.md
@@ -89,11 +89,11 @@ multi-material AMF file.
 
 -   Within Slic3r, load one of the STLs into the plater.
 -   Right-click on the part and select "Settings".
- ![Part Settings Window.](images/part-settings.png "fig:")
+    ![Part Settings Window.](images/part-settings.png "fig:")
 -   Select "Load Part" and select one of the STL files.
 -   Select it in the UI and move it around.
 -   Assign it an extruder.
--   Continue until all parts have been added and positioned. 
--   Click "OK" and right-click the combined part again and select "Export to AMF". 
+-   Continue until all parts have been added and positioned.
+-   Click "OK" and right-click the combined part again and select "Export to AMF".
 
 Once generated the file can be loaded and printed as described above.

--- a/src/expert-mode/print-settings.md
+++ b/src/expert-mode/print-settings.md
@@ -2,7 +2,7 @@
 
 This page will provide an overview of the available configuration settings in
 Slic3r. Every configuration option has a tooltip and it is recommended to read
-those tooltips. 
+those tooltips.
 
 Print Settings
 --------------
@@ -22,13 +22,13 @@ the vertical axis taken before extruding a new layer atop the previous
 one. There are several factors that influence how high each layer should
 be:
 
--   **Desired resolution** - Lower layer height should result in prints
+-   **Desired resolution** &ndash; Lower layer height should result in prints
     with less noticeable ribs or bands, as each layer is smaller.
     Aesthetics plays a role here, but also the type of model, for
     example, a mechanical part may not need such a high resolution
     finish, whereas a presentation piece may do so.
 
--   **Print speed** - Shorter layers will result in smoother prints but
+-   **Print speed** &ndash; Shorter layers will result in smoother prints but
     each print will take longer, simply because the extruder must trace
     the pattern more times. A later goal will be to strike a balance
     between layer height, the speed of the printer, and the quality of
@@ -77,7 +77,7 @@ mechanical strength. A value of 20% is usually the minimum required to
 support flat ceilings.
 
 Slic3r offers several fill patterns which will be discussed in more
-depth in section  - Infill Choices.
+depth in section [Infill Patterns](#infill-patterns).
 Choosing a `Fill pattern` will depend on the kind of model, the desired
 structural strength, print speed, and personal taste. The more exotic
 fill methods are usually too slow and unnecessarily complex for most use
@@ -92,14 +92,14 @@ strength, time and material, personal preference. It can be inferred
 that a more complex pattern will require more moves, and hence take more
 time and material.
 
-Slic3r offers several infill patterns, four regular, and three more
+Slic3r offers several infill patterns: four regular, and three more
 exotic flavours. The numbers given in brackets below each figure are a
 rough estimate of material used and time taken for a simple 20mm cube
 model[^2]. Note that this is only indicative, as model complexity and
 other factors will affect time and material.
 
  ![Infill pattern: Line (344.51mm /
-5m:20s)](images/infill_line.png "fig:") 
+5m:20s)](images/infill_line.png "fig:")
 
  ![Infill pattern: Rectilinear (350.57mm /
 5m:23s)](images/infill_rectilinear.png "fig:")
@@ -110,7 +110,7 @@ other factors will affect time and material.
 
 
  ![Infill pattern: Honeycomb (362.73mm /
-5m:39s)](images/infill_honeycomb.png "fig:") 
+5m:39s)](images/infill_honeycomb.png "fig:")
 
  ![Infill pattern: Hilbert Curve (332.82mm /
 5m:28s)](images/infill_hilbertcurve.png "fig:")
@@ -124,10 +124,9 @@ other factors will affect time and material.
 5m:15s)](images/infill_octagramspiral.png "fig:")
 
 
-Certain model types are more suited for a particular pattern, for
-example organic versus mechanical types. Figure
- shows how a honeycomb fill may
-suit this mechanical part better because each hexagon bonds with the
+Certain model types are more suited for a particular pattern, for example
+organic versus mechanical types. The figure below shows how a honeycomb fill
+may suit this mechanical part better because each hexagon bonds with the
 same underlying pattern each layer, forming a strong vertical structure.
 
  ![Infill pattern comparison in a complex object. Left to Right:
@@ -137,9 +136,9 @@ honeycomb, line](images/complex_object_infill_comparison.png "fig:")
 Most models require only a low density infill, as providing more than,
 say, 50% will produce a very tightly packed model which uses more
 material than required. For this reason a common range of patterns is
-between 10% and 30%, however the requirements of the model will
-determine which density is best. Figure 
-shows how the patterns change as the density increases.
+between 10% and 30%, however the requirements of the model will determine
+which density is best. The figure below shows how the patterns change as the
+density increases.
 
  ![Infill patterns at varying densities. Left to Right:
 20%,40%,60%,80%. Top to Bottom: Honeycomb, Concentric, Line,
@@ -157,33 +156,33 @@ There are several 3D patterns available for 3d infill as well.
 
 
 ##### Infill Optimization
-Slic3r contains several advanced infill settings which can help produce
+Slic3r contains several advanced infill settings that can help produce
 better extrusions.
 
--   `Infill every n layers` - Will produce sparse vertical infill by
+-   `Infill every n layers` &ndash; Will produce sparse vertical infill by
     skipping a set number of layers. This can be used to speed up print
     times where the missing infill is acceptable.
 
--   `Only infill where needed` - Slic3r will analyse the model and
+-   `Only infill where needed` &ndash; Slic3r will analyse the model and
     choose where infill is required in order to support internal
     ceilings and overhangs. Useful for reducing time and materials.
 
--   `Solid infill every n layers` - Forces a solid fill pattern on the
+-   `Solid infill every n layers` &ndash; Forces a solid fill pattern on the
     specified layers. Zero will disable this option.
 
--   `Fill angle` - By default the infill pattern runs at 45° to the
+-   `Fill angle` &ndash; By default the infill pattern runs at 45° to the
     model to provide the best adhesion to wall structures. Infill
     extrusions that run adjacent to perimeters are liable to de-laminate
     under stress. Some models may benefit from rotating the fill angle
     to ensure the optimal direction of the extrusion.
 
--   `Solid infill threshold area` - Small areas within the model are
+-   `Solid infill threshold area` &ndash; Small areas within the model are
     usually best off being filled completely to provide structural
     integrity. This will however take more time and material, and can
     result in parts being unnecessarily solid. Adjust this option to
     balance these needs.
 
--   `Only retract when crossing perimeters` - Retracting, to prevent
+-   `Only retract when crossing perimeters` &ndash; Retracting, to prevent
     ooze, is unnecessary if the extruder remains within the boundaries
     of the model. Care should be taken if the print material oozes
     excessively, as not retracting may result in enough material loss to
@@ -191,7 +190,7 @@ better extrusions.
     printers and materials rarely suffer from such extreme ooze
     problems.
 
--   `Infill before perimeters` - Reverses the order in which the layer
+-   `Infill before perimeters` &ndash; Reverses the order in which the layer
     is printed. Usually the perimeter is laid down initially, followed
     by the infill, and this is usually the preferable as the perimeter
     acts as a wall containing the infill.
@@ -199,12 +198,11 @@ better extrusions.
 #### Support material
 ![Print Settings: Support Material](images/print_settings_4.png "fig:")
 
- Printing a model from the bottom up, as
-with FDM, means that any significant overhangs will be printed in the
-air, and most likely droop or not print correctly. Choosing support
-material (`Generate support material`) will add additional structures
-around the model which will build up to then support the overhanging
-part. The `Pattern spacing` option determines how dense the support
+Printing a model from the bottom up, as with FDM, means that any significant
+overhangs will be printed in the air, and most likely droop or not print
+correctly. Choosing support material (`Generate support material`) will add
+additional structures around the model which will build up to then support the
+overhanging part. The `Pattern spacing` option determines how dense the support
 material is printed.
 
  ![An example of an object printed with support
@@ -214,12 +212,16 @@ material.](images/support_example.jpg "fig:")
 Tip: It is sometimes worth considering altering the orientation of the
 model in order to possibly reduce overhangs.
 
-`Raft layers` will add additional layers underneath the model and stems
-from the early days of 3D printing.
-The following use cases are appropriate for raft usage:
-- Print is using a material that usually requires a heated bed to not warp and there is no heated bed.
-- The bed is not very flat. A raft then absobes the variance in Z for the first layer.
-- The part has a very small contact area with the bed. Usually a wide brim is a better solution.
+`Raft layers` will add additional layers underneath the model and stems from the
+early days of 3D printing. The following use cases are appropriate for raft
+usage:
+
+- Print is using a material that usually requires a heated bed to not warp and
+  there is no heated bed.
+- The bed is not very flat. A raft then absobes the variance in Z for the first
+  layer.
+- The part has a very small contact area with the bed. Usually a wide brim is a
+  better solution.
 
 Otherwise, rafts are generally not recommended. The raft also requires
 post-processing to remove it.
@@ -229,51 +231,51 @@ Rafts are classified as support material, while the top layer of the raft (the o
 #### Speed
 ![Print Settings: Speed](images/print_settings_5.png "fig:")
 
-There are two general categories of speeds: print moves and non-print moves. 
+There are two general categories of speeds: print moves and non-print moves.
 
 For print moves, each type of printing move can be configured to have a
 different speed, either in absolute terms (mm/s) or as a percentage of the
 more general move.
 
--   `Perimeters` - The outline of the model may benefit from being printed
+-   `Perimeters` &ndash; The outline of the model may benefit from being printed
     slightly slower so that the outside skin of the print has fewer blemishes.
 
-    -   `Small perimeters` - Meant for holes, islands and fine details, a
+    -   `Small perimeters` &ndash; Meant for holes, islands and fine details, a
         slower speed here is recommended.
 
-    -   `External perimeters` - A slightly slower value may ensure cleaner
+    -   `External perimeters` &ndash; A slightly slower value may ensure cleaner
         surfaces.
 
--   `Infill` - As the infill is hidden this can be extruded a little
+-   `Infill` &ndash; As the infill is hidden this can be extruded a little
     faster. Take care though not to go too fast as higher speeds results
     in thinner extrusions, and this may affect how the extrusions bond.
 
-    -   `Solid infill` - The bottom of the model, and any additional solid
+    -   `Solid infill` &ndash; The bottom of the model, and any additional solid
         layers is usually slightly slower than infill but faster than
         perimeters.
 
-    -   `Top solid infill` - Allow time for the extrusion to cleanly cover
+    -   `Top solid infill` &ndash; Allow time for the extrusion to cleanly cover
         the previous top layers and result in a tidy top surface. the last
         few layers should have bridged the infill structure nicely,
         preparing the way for a neat finish.
 
-    -   `Gap fill` - Filling in small gaps results in the extruder quickly
+    -   `Gap fill` &ndash; Filling in small gaps results in the extruder quickly
         oscillating and the resulting shaking and resonance could have a
         detrimental affect on the printer. A smaller value here can guard
         against this. Gap fill may be disabled in the 'Infill' settings.
 
--   `Bridges` - Having the extrusion span distances depends on the
+-   `Bridges` &ndash; Having the extrusion span distances depends on the
     material and cooling. Going too slow will result in sagging, too
     fast will result in broken strands. Experimentation is the key here,
     but generally bridging runs slower than perimeters.
 
--   `Support material` - These are used if any support material (including
+-   `Support material` &ndash; These are used if any support material (including
     rafts and brims) is included in the print. Usually it is printed as thick
     as possible, so a high speed may cause flow rate issues.
 
 The one non-print move is travel moves.
 
--   `Travel` - The jump between the end of one extrusion and the next
+-   `Travel` &ndash; The jump between the end of one extrusion and the next
     should usually be performed as quickly as the printer will allow in
     order to minimise any mess caused by material oozing from the
     nozzle.
@@ -297,8 +299,17 @@ rate for any printing moves. Set it to 0 to disable this feature.
 
 There are 2 experimental methods to derive the max extrusion rate:
 
-1. Print fast and use live tuning via M221 until you see or feel the filament slipping in the extruder (easy on a standard UM, maybe more difficult on others, and it heavily depends on the extruder mechanism how much pressure it can deliver without slipping).
-2. Perform the following extruder calibration routine (either manually in pronterface, or with some to-be-done tool): Heat the printe's hotend up a middle of the road temp (i.e. 210C for PLA), and push i.e. 20mm filament through the nozzle at a given speed (steps/sec or mm/sec), starting with i.e. 1mm/s, and observe whether or not the filament was slipping. If not, continue increasing the speed by 20%, and test again. If so, this value indicates a maximum extrusion rate for this temperature has been reached. 
+1. Print fast and use live tuning via M221 until you see or feel the filament
+   slipping in the extruder (easy on a standard UM, maybe more difficult on
+   others, and it heavily depends on how much pressure the extruder mechanism
+   can deliver without slipping).
+2. Perform the following extruder calibration routine (either manually in
+   pronterface, or with some to-be-done tool): Heat the printer's hotend up to a
+   middle-of-the-road temp (i.e. 210C for PLA), and push i.e. 20mm of filament
+   through the nozzle at a given speed (steps/sec or mm/sec), starting with e.g.
+   1mm/s, and observe whether or not the filament was slipping. If not, continue
+   increasing the speed by 20%, and test again. If so, this value indicates a
+   maximum extrusion rate for this temperature has been reached.
 
 ##### Recommendations
 
@@ -314,49 +325,49 @@ The best approach is to increment the various speed parameters in small
 steps and observe the effect each change has on print quality. Travel
 speed is a safe starting point, and it is not unrealistic to attain
 speeds of up to 250mm/s (if your printer can handle it). Adjusting the
-speed of perimeters, infill is available in simple mode, and the general
+speed of perimeters and infill is available in simple mode, and the general
 rule is to have the perimeter go a little slower than the infill in
-order to reduce possible blemishes on the surface (infill can be faster
-because slight gaps will not matter as much).
+order to reduce possible blemishes on the surface. (Infill can be faster
+because slight gaps will not matter as much.)
 
 #### Skirt and Brim
 ![Print Settings: Skirt and Brim](images/print_settings_3.png "fig:")
 
 ##### Brim
 
- `Brim width` is used to add more perimeters to the first layer, as a base
- flange, in order to provide more surface area for the print to stick to the
- bed with in order to reduce warping (see §). The brim is then cut away once
- the print is finished and removed from the bed. `Interior brim width` adds a
- brim inside of holes in the print.
+`Brim width` is used to add more perimeters to the first layer, as a base
+flange, in order to provide more surface area for the print to stick to the
+bed with in order to reduce warping (see §). The brim is then cut away once
+the print is finished and removed from the bed. `Interior brim width` adds a
+brim inside of holes in the print.
 
  ![An example of brim.](images/brim.jpg "fig:")
- 
- `Brim ears` will print the brim only around sharp corners. The 
- `Brim ears Maximum Angle` setting allow to choose the sharpness of the angle.
- An angle below 90° won't draw a grim ear around each corner of a cube, but 
- an angle of 91° will.
+
+`Brim ears` will print the brim only around sharp corners. The
+`Brim ears Maximum Angle` setting allow to choose the sharpness of the angle.
+An angle below 90° won't draw a brim ear around each corner of a cube, but
+an angle of 91° will. (Brim ears appears in release 1.3.1.)
 
  ![An example of brim ears. (model made by b1sh0p)](images/brim_ears.jpg "fig:")
- 
+
 ##### Skirt
 
 The `Skirt` setting adds an extrusion a short distance away from the
 perimeter of the object. This can ensure that the material is flowing
 smoothly from the extruder before it starts on the model proper.
 
--   `Loops` - How many circuits should be completed before starting on
+-   `Loops` &ndash; How many circuits should be completed before starting on
     the model. One loop is usually sufficient.
 
--   `Distance from object` - The millimeters between the object and the
+-   `Distance from object` &ndash; The millimeters between the object and the
     skirt. The default of 6mm is usually sufficient.
 
--   `Skirt height` - The number of layers to lay down a skirt for. For
+-   `Skirt height` &ndash; The number of layers to lay down a skirt for. For
     ensuring the material is flowing smoothly, one layer is sufficient,
     however the skirt function can also be used to build walls around
     the object in case it should be protected from draughts.
 
--   `Minimum extrusion length` - Dictates a minimum number of
+-   `Minimum extrusion length` &ndash; Dictates a minimum number of
     millimeters that the skirt should be, should the loop around the
     object not be enough.
 
@@ -367,19 +378,19 @@ smoothly from the extruder before it starts on the model proper.
 
 One reason for modifying the extrusion width has already been discussed:
 increasing first layer extrusion width in order to improve bed adhesion
-(see p.). There are some further cases where it may be beneficial to
-modify extrusion widths.
+(see [The Important First Layer](#../first-print/first-layer)). There are some
+further cases where it may be beneficial to modify extrusion widths.
 
--   `Perimeter` - A lower value will produce thinner extrusions which in
+-   `Perimeter` &ndash; A lower value will produce thinner extrusions which in
     turn will produce more accurate surfaces.
 
--   `Infill` and `Solid Infill` - A thicker extrusion for infill will
+-   `Infill` and `Solid Infill` &ndash; A thicker extrusion for infill will
     produce faster prints and stronger parts.
 
--   `Top infill` - A thinner extrusion will improve surface finish and
+-   `Top infill` &ndash; A thinner extrusion will improve surface finish and
     ensure corners are tightly filled.
 
--   `Support material` - As with the infill options, a thicker extrusion
+-   `Support material` &ndash; As with the infill options, a thicker extrusion
     will speed up print time.
 
 It is important to remember that if the extrusion width is expressed as
@@ -391,19 +402,24 @@ not the `Default extrusion width` setting.
 
 ##### Sequential Printing.
 
- This feature allows to compose a plate of objects but have the printer
- complete each one individually before going back to Z = 0 and starting with
- the next one. See the section about Sequential Printing in the Advanced Topics
- chapter.
+This feature allows the user to compose a plate of objects but have the printer
+complete each one individually before going back to Z = 0 and starting with
+the next one. See the section about Sequential Printing in the Advanced Topics
+chapter.
 
 ##### Output File Options
 
-- `Verbose G-Code` turns on extra comments to document the types of print moves in the output G-Code. Very useful for debugging. 
-- `Output filename format` describes the general format for how Slic3r automatically names export G-Code files. All of the usual variables are supported here.
+- `Verbose G-Code` turns on extra comments to document the types of print moves
+  in the output G-Code. Very useful for debugging.
+- `Output filename format` describes the general format for how Slic3r
+  automatically names export G-Code files. All of the usual variables are
+  supported here.
 
 ##### Post-Processing Scripts
 
-Post-processing scripts are a powerful way to modify output G-Code after the slicing process has completed and as such have their own section in Advanced Topics.
+Post-processing scripts are a powerful way to modify output G-Code after the
+slicing process has completed and as such have their own section in Advanced
+Topics.
 
 #### Shortcuts
 ![Print Settings: Shortcuts](images/print_settings_shortcuts.png "fig:")

--- a/src/expert-mode/printer-settings.md
+++ b/src/expert-mode/printer-settings.md
@@ -11,7 +11,7 @@ to be used for many printers, for example, in a 3D printer farm.
 
 #### Size and coordinates.
 
- The `Bed size` setting is taken from the
+The `Bed size` setting is taken from the
 wizard (see p.) and is only used for previewing the model in the plater.
 
 The `Print center` is the point around which the print will be centered.
@@ -29,12 +29,11 @@ The optimal Z endstop position is where the nozzle tip barely touches
 the surface of the bed when homed. A sheet of paper makes a good gauge
 for this very small distance. It is not recommended to use this setting
 to try and improve layer adhesion, by "squashing" the bottom layer into
-the bed, instead look at the suggestions in section
-.
+the bed, instead look at the suggestions in the appropriate section.
 
 #### Firmware.
 
- As selected in the wizard (see p.), `G-code flavour`
+As selected in the wizard (see p.), `G-code flavour`
 defines the dialect of G-code generated.
 
 ### Extruder Settings
@@ -42,11 +41,11 @@ defines the dialect of G-code generated.
 
 #### Extruder.
 
- `Nozzle diameter` was defined in the wizard (see p.).
+`Nozzle diameter` was defined in the wizard (see p.).
 
 #### Retraction.
 
- Unless the material being extruded has a very high
+Unless the material being extruded has a very high
 viscosity it may ooze between extrusions due to gravity. This can be
 remedied by actively retracting the filament between extrusions. Setting
 the `Length` parameter to a positive value will cause the filament to be
@@ -65,37 +64,38 @@ speed. A value of 0.1mm is usually sufficient.
 ### Custom G-Code
 #### Start, End and Layer Change G-Codes.
 ![Printer Settings: Custom G-Code (1)](images/printer_settings_custom_gcode1.png "fig:")
+
 ![Printer Settings: Custom G-Code (2)](images/printer_settings_custom_gcode_2.png "fig:")
 
- Custom G-code commands can be run before a print
+Custom G-code commands can be run before a print
 starts and after a print finishes.
 
 Placeholders can be inserted in the G-code commands[^1]. For example
 [next\_extruder] would return the index of the next extruder.
 
-The RepRap wiki is a good resource to learn about the variety of G-codes
-available: `http://reprap.org/wiki/G-code`.
+The [RepRap wiki](http://reprap.org/wiki/G-code) is a good resource to learn
+about the variety of G-codes available.
 
 Note: Be sure to check that a given G-code is valid for your firmware.
 
 The codes specified in `Start G-code` are inserted at the beginning of
-the output file, directly after the temperature control commands for
+the output file, directly after the temperature control commands for the
 extruder and bed. Note that if temperature control commands are
 specified (M104 and M190) then these will replace the temperature
 G-codes introduced by the `Filament` settings.
 
 Some common G-codes to use before the print starts are:
 
--   **G28** - Homes all the axes.
+-   **G28** &ndash; Homes all the axes.
 
 Some common G-codes to use after the print ends are:
 
--   **M104 S0** - Sets the extruder temperature to zero.
+-   **M104 S0** &ndash; Sets the extruder temperature to zero.
 
--   **M140 S0** - Sets the heated bed temperature to zero.
+-   **M140 S0** &ndash; Sets the heated bed temperature to zero.
 
--   **G28 X0** - Home the X axis.
+-   **G28 X0** &ndash; Home the X axis.
 
--   **M84** - Disables the motors.
+-   **M84** &ndash; Disables the motors.
 
 [^1]: https://github.com/alexrj/Slic3r/wiki/FAQ\#what-placeholders-can-i-use-in-custom-g-code

--- a/src/expert-mode/variable-layer-height.md
+++ b/src/expert-mode/variable-layer-height.md
@@ -8,9 +8,12 @@ gradients where layering appears more pronounced.
 
 The layer thickness distribution can be influenced by:
 
-- automatic pre-computing of good thicknesses with [Adaptive Slicing](#adaptive-slicing)
-- interactive refinement in the [Adaptive Layers](#interactive-layer-refinement) settings tab
-- setting a fixed layer height for a particular range in the [Layer height table](#static-layer-height-table) setting tab
+- automatic pre-computing of good thicknesses with
+  [Adaptive Slicing](#adaptive-slicing)
+- interactive refinement in the [Adaptive Layers](#interactive-layer-refinement)
+  settings tab
+- setting a fixed layer height for a particular range in the
+  [Layer height table](#static-layer-height-table) setting tab
 
  ![Example model highlighting use case for variable layer
 heights.](images/variable_layer_height/example_model.png)
@@ -27,44 +30,44 @@ Adaptive Slicing {#adaptive-slicing}
 Maintaining a good balance between printing time and quality is a fundamental
 trade-off problem for 3D printing.
 
-If the `Use adaptive slicing` option is enabled, Slic3r automatically
-computes the individual thickness of each layer based on the angle of the surface.
+If the `Use adaptive slicing` option is enabled, Slic3r automatically computes
+the individual thickness of each layer based on the angle of the surface.
 Technical details are provided in a paper [^1].
 
-The `Adaptive quality` option adjusts the overall quality between 0% - thickest
-printable layers over the entire object to 100% - thinnest possible layers.
+The `Adaptive quality` option adjusts the overall quality between 0% &mdash;
+thickest printable layers over the entire object to 100% &mdash; thinnest
+possible layers.
 
 The `Z full steps/mm` parameter is always respected by the adaptive slicing
-process, also the `Combine infill` logic is not affected.
+process; also the `Combine infill` logic is not affected.
 Example: if `Combine infill` is set to 3, Slic3r will combine up to 3 infill
 layers, even if those layers are of different thickness. The number of combined
 layers will vary along the Z axis, depending on the local thickness of layers.
 
 
-
- ![Activate adaptive slicing and set desired quality in the Print settings 
- dialog.](images/variable_layer_height/settings_dialog.png)
+![Activate adaptive slicing and set desired quality in the Print settings
+dialog.](images/variable_layer_height/settings_dialog.png)
 
 Upper and lower limits for the layer thickness are set per extruder in the
 `Printer Settings` tab. Slic3r automatically uses the values for all extruders
-which are used for a particular print. If for example only one extruder is used
+that are used for a particular print. If for example only one extruder is used
 from a dual nozzle printer, the limits of the second extruder won't reduce the
 maximum layer thickness.
 
- ![Set the minimum / maximum possible layer thickness for each extruder
- in the Printer settings.](images/variable_layer_height/min_max_settings_dialog.png)
+![Set the minimum / maximum possible layer thickness for each extruder
+in the Printer settings.](images/variable_layer_height/min_max_settings_dialog.png)
 
 Interactive Layer Refinement {#interactive-layer-refinement}
 ----------------
 
 A tool to interactively refine the layer heights of an object is available by
 double clicking an object in the 3D tab or taking the `Layer heights...`
-short-cut on the Plater. This opens `Adaptive Layers` tab in the Settings
+short-cut on the Plater. This opens the `Adaptive Layers` tab in the Settings
 dialogue, where the layer thickness curve can be modified for each individual
 model on the plater.
 
- ![Variable layer height
- control curve.](images/variable_layer_height/model_adaptive_control.png)
+![Variable layer height
+control curve.](images/variable_layer_height/model_adaptive_control.png)
 
 Use the mouse to drag the layer height curve:
 
@@ -73,14 +76,14 @@ range and horizontally to set the layer height.
 - Left click to trigger quadratic manipulation. Use this to generate smooth
 thickness transitions.
 
-  ![Screenshot of linear
-  manipulation.](images/variable_layer_height/screenshot_linear.png)
-  ![Screenshot of quadratic
-  manipulation.](images/variable_layer_height/screenshot_quadratic.png)
+![Screenshot of linear
+manipulation.](images/variable_layer_height/screenshot_linear.png)
+![Screenshot of quadratic
+manipulation.](images/variable_layer_height/screenshot_quadratic.png)
 
-  ![The same object printed with static thick layers (**left**), static thin
-  layers (**center**) and adaptive layers 
-  (**right**).](images/variable_layer_height/lm8uu_prints.png)
+![The same object printed with static thick layers (**left**), static thin
+layers (**center**) and adaptive layers 
+(**right**).](images/variable_layer_height/lm8uu_prints.png)
 
 
 Static Layer Height Table {#static-layer-height-table}
@@ -88,7 +91,7 @@ Static Layer Height Table {#static-layer-height-table}
 
 The layer height table allows to define a layer height for a particular
 range along the Z axis, given in millimeters.
-The values from this table will override both, the default and adaptively
+The values from this table will override both the default and adaptively
 generated layer heights, but not the interactively modified curve in the
 `Adaptive layers` tab.
 

--- a/src/first-print/calibration.md
+++ b/src/first-print/calibration.md
@@ -5,7 +5,7 @@ correctly calibrated. Skipping or rushing this step will result in
 frustration and failed prints later, so it is important to take the time
 to make sure the machine is correctly set up.
 
-Each machine may have it’s own calibration procedure and this manual
+Each machine may have its own calibration procedure and this manual
 will not attempt to cover all the variations. Instead here is a list of
 key points that should be addressed.
 

--- a/src/first-print/configuration-wizard.md
+++ b/src/first-print/configuration-wizard.md
@@ -31,12 +31,12 @@ extruder may travel along the X and Y axis. If the dimensions are not
 readily available for the printer then it can be easily measured.
 
 Be sure to measure from the lower left corner where the extruder nozzle
-rests when are the home position to the maximum distance the nozzle can
+rests when at the home position to the maximum distance the nozzle can
 travel in each direction. Take into account that the X carriage may
 touch the frame before the nozzle reaches it’s full distance, this will
 depend on the printer make and model.
 
-Also remember to check any firmware end-stop settings which may limit
+Also remember to check any firmware end-stop settings that may limit
 X/Y movement.
 
  ![Configuration Wizard: Bed
@@ -46,10 +46,9 @@ Size](images/configuration-wizard/configuration_wizard_bed_size.png "fig:")
 3. Nozzle Diameter
 ------------------
 
- The diameter of the hot-end nozzle is usually
-clearly displayed either in the description of the hot-end, or in the
-associated documentation, when the hot-end is purchased. Common values
-are 0.5mm and 0.35mm.
+The diameter of the hot-end nozzle is usually clearly displayed either in
+the description of the hot-end, or in the associated documentation, when the
+hot-end is purchased. Common values are 0.5mm and 0.35mm.
 
 If the nozzle was home-made, or came from a source without a diameter
 given, then carefully measure the aperture as accurately as possible.
@@ -66,10 +65,9 @@ Diameter](images/configuration-wizard/configuration_wizard_nozzle_diameter.png "
 4. Filament Diameter
 --------------------
 
- For Slic3r to produce accurate results it
-must know as accurately as possible how much material is pushed through
-the extruder. Therefore it is vital to give it as precise a value as
-possible for the filament diameter.
+For Slic3r to produce accurate results it must know as accurately as possible
+how much material is pushed through the extruder. Therefore it is vital to give
+it as precise a value as possible for the filament diameter.
 
 Although the filament used in FDM printers is sold as being either 3mm
 or 1.75mm this is only a general guide. The diameter can vary between
@@ -86,18 +84,17 @@ Diamter](images/configuration-wizard/configuration_wizard_filament_diameter.png 
 5. Extrusion Temperature
 ------------------------
 
- The extrusion temperature will depend on
-the material, and most can operate over a range of temperatures. The
-supplier should provide guidance as to which temperatures are suitable.
-A very general rule of thumb is that PLA lies between 160°C and 230°C,
-and ABS lies between 215°C and 250°C. More exotic materials will have a
-different range.
+The extrusion temperature will depend on the material, and most can operate
+over a range of temperatures. The supplier should provide guidance as to which
+temperatures are suitable. A very general rule of thumb is that PLA lies between
+160°C and 230°C, and ABS lies between 215°C and 250°C. More exotic materials
+will have a different range.
 
-This is one parameter which you will want to fine tune when you start
-producing prints. The optimal temperature can vary even between colours
-of the same material. Another factor which may affect the chosen
+This is one parameter which you will want to fine tune when you start producing
+prints. The optimal temperature can vary even between colours of the same
+material from the same manufacturer. Another factor that may affect the chosen
 temperature is how fast the extrusion is, where generally faster
-extrusion runs hotter.
+extrusion requires a higher temperature.
 
 Note: One may choose to control the extruder temperature manually from
 the printer controller. In this case the temperature can be set to zero.
@@ -109,10 +106,9 @@ Temperature](images/configuration-wizard/configuration_wizard_extrusion_temperat
 6. Bed Temperature
 ------------------
 
- If the printer has a heated bed then this
-parameter may be set. As with the extruder temperature, the value will
-depend on the material used. A rule of thumb is that PLA requires  60°C
-and ABS requires  110°C.
+If the printer has a heated bed then this parameter may be set. As with the
+extruder temperature, the value will depend on the material used. A rule of
+thumb is that PLA requires 60°C and ABS requires 110°C.
 
 Note: One may choose to control the bed temperature manually from the
 printer controller. In this case the temperature can be set to zero.
@@ -121,8 +117,7 @@ printer controller. In this case the temperature can be set to zero.
 Temperature](images/configuration-wizard/configuration_wizard_bed_temperature.png "fig:")
 
 
-At this stage the wizard is complete and the basic configuration is
-defined.
+At this stage the wizard is complete and the basic configuration is defined.
 
  ![Configuration Wizard:
 End](images/configuration-wizard/configuration_wizard_end.png "fig:")

--- a/src/first-print/first-layer.md
+++ b/src/first-print/first-layer.md
@@ -1,6 +1,6 @@
 % The Important First Layer
 
- Before delving into producing the
+Before delving into producing the
 first print it is worthwhile taking a little detour to talk about the
 importance of getting the first layer right. As many have found through
 trial and error, if the first layer is not the best it can be then it
@@ -10,7 +10,7 @@ the chance of this happening.
 
 #### Level bed.
 
- Having a level bed is critical. If the distance between
+Having a level bed is critical. If the distance between
 the nozzle tip and the bed deviates by even a small amount it can result
 in either the material not lying down on the bed (because the nozzle is
 too close and scrapes the bed instead), or the material lying too high
@@ -18,31 +18,31 @@ from the bed and not adhering correctly.
 
 #### Higher temperature.
 
- The extruder hot-end and bed, if it is heated,
+The extruder hot-end and bed, if it is heated,
 can be made hotter for the first layer, thus decreasing the viscosity of
 the material being printed. As a rule of thumb, an additonal 5° is
 recommended.
 
 #### Lower speeds.
 
- Slowing down the extruder for the first layer
+Slowing down the extruder for the first layer
 reduces the forces applied to the molten material as it emerges,
 reducing the chances of it being stretched too much and not adhering
 correctly. 30% or 50% of the normal speed is recommended.
 
 #### Correctly calibrated extrusion rates.
 
- If too much material is laid down
+If too much material is laid down
 then the nozzle may drag through it on the second pass, causing it to
 lift off the bed (particularly if the material has cooled). Too little
 material may result in the first layer coming loose later in the print,
 leading either to detached objects or warping. For these reasons it is
 important to have a well-calibrated extrusion rate as recommended in
-§[calibration]).
+[calibration](./calibration).
 
 #### First layer height.
 
- A thicker layer height will provide more
+A thicker layer height will provide more
 flow, and consequently more heat, making the extrusion adhere to the bed
 more. It also gives the benefit of giving more tolerance for the
 levelness of the bed. It is recommended to raise the first layer height
@@ -52,7 +52,7 @@ automatically in simple mode.
 
 #### Fatter extrusion width.
 
- The more material touching the bed, the
+The more material touching the bed, the
 better the object will adhere to it, and this can be achieved by
 increasing the extrusion width of the first layer, either by a
 percentage or a fixed amount. Any spaces between the extrusions are
@@ -67,11 +67,11 @@ nozzle. This would cause poor flow and lead to a failed print. It is
 therefore highly recommended to combine the high first layer height
 technique recommended above with this one. Setting the first layer
 height to 0.35mm and the first extrusion width to 200% would result in a
-nice fat extrusion 0.65mm wide.
+nice fat extrusion 0.7mm wide.
 
 #### Bed material.
 
- Many options exist for the material to use for the
+Many options exist for the material to use for the
 bed, and preparing the right surface can vastly improve first layer
 adhesion.
 
@@ -86,7 +86,7 @@ keep the print attached.
 
 #### No cooling.
 
- Directly related with the above, it makes no sense to
+Directly related with the above, it makes no sense to
 increase the temperature of the first layer and still have a fan or
 other cooling mechanism at work. Keeping the fan turned off for the
 first few layers is generally recommended.

--- a/src/first-print/working-with-models.md
+++ b/src/first-print/working-with-models.md
@@ -1,12 +1,13 @@
 % Working with Models
 
-Yet another step lies between now and the first print - a model has to
+Yet another step lies between now and the first print &mdash; a model has to be
 found and then sliced.
 
 Model Formats
 -------------
 
-Slic3r accepts the following file types. A more detailed description of the formats is given in the Topics section.
+Slic3r accepts the following file types. A more detailed description of the
+formats is given in the Topics section.
 
 -   STereoLithography (STL) files can come from a wide variety of
     sources and are now a de facto standard in 3D printing. The files
@@ -15,8 +16,8 @@ Slic3r accepts the following file types. A more detailed description of the form
     simplicity that has probably made the format ubiquitous.
 
 -   Wavefront OBJ files are an open format originally used in an
-    animation application from Wavefront Technologies, but has since
-    been adopted by the wider 3D modelling community. It is similar to
+    animation application from Wavefront Technologies, but since then
+    adopted by the wider 3D modelling community. It is similar to
     the STL format.
 
 -   Additive Manufacturing File Format (AMF) was developed in response
@@ -27,9 +28,8 @@ Slic3r accepts the following file types. A more detailed description of the form
     format is deemed a standard it has yet to be widely adopted in the
     3D maker community.
 
--   [3MF](https://3mf.io/) is a XML-based file format, similar to AMF in
-    features and capabilities.
-    It is supported natively by Windows 3D Builder.
+-   [3MF](https://3mf.io/) is an XML-based file format, similar to AMF in
+    features and capabilities. It is supported natively by Windows 3D Builder.
 
 Finding Models
 --------------
@@ -40,16 +40,15 @@ as FreeCAD[^3], Sketchup[^4], or OpenSCAD[^5], or an online CAD tool
 such as Shapesmith[^6].
 
 You may wish to view the files before slicing and there are many free
-applications available, one of which is Meshlab[^7] - a comprehensive
+applications available, one of which is Meshlab[^7] &mdash; a comprehensive
 tool for viewing and working with 3D files.
 
- ![Shapesmith online CAD
-tool.](images/working-with-models/shapesmith.png "fig:") 
+ ![Shapesmith online CAD tool.](images/working-with-models/shapesmith.png "fig:")
 
 Working with Plater
 -------------------
 
- Slic3r has a tool, called Plater, which
+Slic3r has a tool, called Plater, which
 allows one or more models to be loaded and arranged before being sliced.
 
  ![Plater](images/working-with-models/plater.png "fig:") 
@@ -57,7 +56,7 @@ allows one or more models to be loaded and arranged before being sliced.
 Once you have acquired a model, drag it onto the Plater window (or use
 the Add button below the file list) to load it into Slic3r. In the
 figure below, the traditional RepRap Minimug[^8] is loaded, and is
-viewed from above. The ring around the model is a skirt - a single
+viewed from above. The ring around the model is a skirt &mdash; a single
 perimeter, several millimeters away from the model, which is extruded
 first. This is useful in making sure the plastic is flowing smoothly
 from the nozzle when the model is starting to be printed.
@@ -65,8 +64,7 @@ from the nozzle when the model is starting to be printed.
  ![Minimug model.](images/working-with-models/minimug_model.png "fig:")
 
 
- ![STL file
-loaded.](images/working-with-models/plater_model_loaded.png "fig:")
+ ![STL file loaded.](images/working-with-models/plater_model_loaded.png "fig:")
 
 
 The model can be repositioned by dragging the representation of it on
@@ -75,12 +73,14 @@ bed should match your printer, as given during the initial configuration
 above.
 
 You can move a selected instance using keyboard.
+
 * On MacOS and Linux: You can use either <kbd>↑</kbd>, <kbd>↓</kbd>, <kbd>←</kbd>, <kbd>→</kbd> or  <kbd>W</kbd>, <kbd>A</kbd>, <kbd>S</kbd>, <kbd>D</kbd>.
 * On Windows: You can use **only** <kbd>W</kbd>, <kbd>A</kbd>, <kbd>S</kbd>, <kbd>D</kbd>.
 
 ![2D Plater View.](images/working-with-models/rsz_2d_plater.png "fig:")
 
 You are also able to configure the displacement or nudge value. To change the nudge value (it's 1mm by default):
+
 * Press <kbd>Ctrl</kbd> or <kdb>⌘ Command</kbd> + <kbd>,</kbd>.
 
 In the "2D plater nudge value" box you can assign integer values as well as decimal values (the minimum value is 0.1 mm).
@@ -94,44 +94,43 @@ You can use the select prev. or select next object shortcuts <kbd>Ctrl</kbd> or 
 On the right-hand side is the list of currently loaded files. The
 buttons along the top of the file list allow you to arrange the models.
 
--   **More/Less** - Adjust how many copies should be printed.
+-   **More/Less** &ndash; Adjust how many copies should be printed.
 
--   **45°/Rotate** - Rotate the selected model around the Z axis, either
+-   **45°/Rotate** &ndash; Rotate the selected model around the Z axis, either
     in 45° increments clockwise or counter-clockwise, or by a given
     amount.
 
--   **Scale** - Increase or decrease the size of the printed model.
+-   **Scale** &ndash; Increase or decrease the size of the printed model.
 
--   **Split** - Divides a model which consists of more than one part
-    into it’s constituent parts, allowing each one to be arranged
+-   **Split** &ndash; Divides a model that consists of more than one part
+    into its constituent parts, allowing each one to be arranged
     individually.
 
 The buttons along the bottom of the file list allow you to add, remove,
 auto-arrange, or export the models.
 
--   **Add** - Opens a file dialog to add a model to the plater, as an
+-   **Add** &ndash; Opens a file dialog to add a model to the plater, as an
     alternative to dropping a file directly.
 
--   **Delete/Delete All** - Remove one or all models from the plater.
+-   **Delete/Delete All** &ndash; Remove one or all models from the plater.
 
--   **Autoarrange** - Attempt to arrange the models to give an optimal
+-   **Autoarrange** &ndash; Attempt to arrange the models to give an optimal
     layout.
 
--   **Export G-code** - Starts slicing the model and produces a G-Code
+-   **Export G-code** &ndash; Starts slicing the model and produces a G-Code
     file.
 
--   **Export STL** - Save the current set of models as a single STL
+-   **Export STL** &ndash; Save the current set of models as a single STL
     file.
 
 Cleaning STLs
 -------------
 
- If the 3D mesh described in the model contains
-holes, or edges are misaligned (known as being non-manifold), then
-Slic3r may have problems working on it. Slic3r will attempt to fix any
-problems it can, but some problems are out of its reach. If the
-application complains that a model cannot be sliced correctly then there
-are several options available: see the chapter about Repairing Models.
+If the 3D mesh described in the model contains holes or if edges are misaligned
+(known as being non-manifold), then Slic3r may have problems working on it.
+Slic3r will attempt to fix any problems it can, but some problems are out of
+its reach. If the application complains that a model cannot be sliced correctly
+then there are several options available: see the chapter about Repairing Models.
 
 [^1]: <http://www.thingiverse.com>
 

--- a/src/getting-slic3r/getting-slic3r.md
+++ b/src/getting-slic3r/getting-slic3r.md
@@ -14,7 +14,7 @@ Source
 
 The source code is available via GitHub:
 <https://github.com/slic3r/Slic3r>. For more details on building from
-source see § below.
+source see [Building from source](#building-from-source) below.
 
 Installing
 ==========
@@ -22,14 +22,15 @@ Installing
 Windows
 -------
 
-Unzip the downloaded zip file to a folder of your choosing, there is no
+Unzip the downloaded zip file to a folder of your choosing; there is no
 installer script. The resulting folder contains three executables:
 
 -   `Slic3r.exe` - starts the GUI version.
 
 -   `Slic3r-console.exe` - can be used from the command line.
 
--   `Slic3r-debug-console.exe` - starts the GUI version and provides a debugging output console.
+-   `Slic3r-debug-console.exe` - starts the GUI version and provides a debugging
+    output console.
 
 The folder also contains a `libexec` directory, which contains the rest of the
 important support files for Slic3r. Do not remove this folder or move it away
@@ -40,17 +41,16 @@ The zip file may then be deleted.
 Mac OS X
 --------
 
-Double-click the downloaded dmg file, an instance of Finder should open
-together with an icon of the Slic3r program. Navigate to the
-Applications directory and drag and drop the Slic3r icon into it. The
-dmg file may then be deleted.
+Double-click the downloaded dmg file. An instance of Finder should open together
+with an icon of the Slic3r program. Navigate to the Applications directory and
+drag and drop the Slic3r icon into it. The dmg file may then be deleted.
 
 Linux
 -----
 
-Extract the archive to a folder of your choosing.  Start Slic3r directly by
+Extract the archive to a folder of your choosing. Start Slic3r directly by
 running the Slic3r shell script, found in the root directory.
-    
+
 
 The archive file may then be deleted.
 

--- a/src/intro/getting-support.md
+++ b/src/intro/getting-support.md
@@ -32,21 +32,22 @@ Guidelines for reporting an issue
 ---------------------------------
 
 Keep in mind that developers are working on a volunteer basis, and the volume
-of requests related to Slic3r is overwhelming, so **please** understand that 
-the most **complete and clear report** you make more chances are that you'll get
-help and attention.
+of requests related to Slic3r is overwhelming, so **please** understand that
+your chances of getting help and attention increase if you make the most
+**complete and clear report** of your issue possible.
 
-* There is a good chance that the issue, you have encountered, is already reported.
+* There is a good chance that the issue you have encountered is already reported.
   Please check the [list of reported issues](https://github.com/alexrj/Slic3r/issues)
-  before creating a new issue report. If you find an existing issue report, feel free
-  to add further information to that report.
-* Include **STL file and config.ini** (exported from *File* -> *Export config...*)
-  that can be used to **reproduce the issue**.
-* Include **screenshots of the G-code preview** demonstrating that the issue can be
-  seen in the G-code and it's not caused by mechanical problems or by the firmware.
-* Specify Slic3r version (or commit number) and operating system.
-* Make sure the STL file is manifold (failure to repair a broken model is not
-  considered a bug; we only deal with bugs reproducible with valid models).
+  before creating a new issue report. If you find an existing issue report, feel
+  free to add further information to that report.
+* Include **STL file** and **config.ini** (exported from *File* ->
+  *Export config...*) that can be used to **reproduce the issue**.
+* Include **screenshots of the G-code preview** demonstrating that the issue can
+  be seen in the G-code and it's not caused by mechanical problems or by the
+  firmware.
+* Specify the Slic3r version (or commit number) and operating system.
+* Make sure the STL file is manifold. (Failure to repair a broken model is not
+  considered a bug; we only deal with bugs reproducible with valid models.)
 * Include one issue per report. If you encounter multiple, unrelated issues,
   please report them as such.
 
@@ -56,8 +57,10 @@ Guidelines for requesting features
 Slic3r is a community project, and features are usually added whenever there is
 general consensus on them. Please start by describing your *goal* by showing
 a concrete case. Show G-code of a real case produced with current Slic3r
-and describe what would you like to improve and why. Put efforts into documenting
+and describe what would you like to improve and why. Put effort into documenting
 this with pictures, G-code preview screenshots, close inspection.
 
-After you're focused on **why** you can move onto ideas for **how** to achieve that
-goal. But don't invert the order and the efforts.
+After you're focused on **why** you can move onto ideas for **how** to achieve
+that goal. But don't invert the order and the efforts. Provide *requirements* for
+what you would like Slic3r to accomplish, rather than plans for how to implement
+your feature.

--- a/src/intro/overview.md
+++ b/src/intro/overview.md
@@ -4,13 +4,13 @@
 
 *Original manual written by Gary Hodgson, with various other contributions.*
 
-Slic3r is a tool which translates digital 3D models into instructions
+Slic3r is a tool that translates digital 3D models into instructions
 that are understood by a 3D printer. It slices the model into horizontal
 layers and generates suitable paths to fill them.
 
 Slic3r is already bundled with the many of the most well-known host
-software packages: Pronterface, Repetier-Host, ReplicatorG, and can be
-used as a standalone program.
+software packages, e.g. Pronterface, Repetier-Host, ReplicatorG, and it can
+be used as a standalone program.
 
 This manual will provide guidance on how to install, configure and
 utilise Slic3r in order to produce excellent prints.
@@ -19,8 +19,8 @@ Goals & Philosophy
 ==================
 
 Slic3r is an original project started in 2011 by Alessandro Ranellucci
-(aka. Sound). Readability and maintainability of the code are among the 
-design goals, as well as power and flexibility. Slic3r aims to be a 
+(aka. Sound). Readability and maintainability of the code are among the
+design goals, as well as power and flexibility. Slic3r aims to be a
 professional CAM tool.
 
 The program is under constant refinement, from Alessandro and the other

--- a/src/topics/draft-quality.md
+++ b/src/topics/draft-quality.md
@@ -1,27 +1,50 @@
 % Draft Quality
 
-Several options can be disabled or tuned in order to achieve faster G-code generation speed and shorter print times.
+Several options can be disabled or tuned in order to achieve faster G-code
+generation speed and shorter print times.
 
 ### Print Settings > Layers and perimeters > Quality
 
 ![Quality options](images/draft_quality_options.png)
 
-These options provide nicer and cleaner objects but require more CPU time. They can be disabled for draft quality prints.
+These options provide nicer and cleaner objects but require more CPU time. They
+can be disabled for draft quality prints.
 
-* `Extra perimeters if needed`: this feature checks whether adding more perimeters to sloping layers would help hiding the internal infill, thus make the object look nicer.
-* `Avoid crossing perimeters`: this feature blends travel moves so that the nozzle stays fully inside or outside the object whenever possible, thus reducing the number of times it crosses perimeters and triggers a retraction. This prevents stringing but requires much CPU time during G-code export because complex motion planning algorithms are used for each single layer.
-* `Detect thin walls`: this feature checks for collisions between perimeters. It ensures that the printer doesn't try to extrude too close paths, and uses the medial axis algorithm in order to transform thin walls into single-pass extrusions.
-* `Detect bridging perimeters`: this feature detects the bridging/overhanging portions of perimeters and applies bridge flow/speed to them.
+* `Extra perimeters if needed` &ndash; this feature checks whether adding more
+  perimeters to sloping layers would help hiding the internal infill, thus make
+  the object look nicer.
+* `Avoid crossing perimeters`&ndash; this feature blends travel moves so that the
+  nozzle stays fully inside or outside the object whenever possible, thus
+  reducing the number of times it crosses perimeters and triggers a retraction.
+  This prevents stringing but requires more CPU time during G-code export because
+  complex motion planning algorithms are used for each single layer, and
+  potentially longer print times as the nozzle may not be able to always take the
+  most direct path when traveling.
+* `Detect thin walls` &ndash; this feature checks for collisions between
+  perimeters. It ensures that the printer doesn't try to extrude too close
+  paths, and uses the medial axis algorithm in order to transform thin walls
+  into single-pass extrusions.
+* `Detect bridging perimeters` &ndash; this feature detects the
+  bridging/overhanging portions of perimeters and applies bridge flow/speed to
+  them.
 
 ### Print Settings > Infill
 
-The *Hilbert Curve*, *Archimedean Chords* and *Octagram Spiral* infill patterns are generally much slower. You might want to avoid them in your draft quality prints if you care about slicing speed.
+The *Hilbert Curve*, *Archimedean Chords* and *Octagram Spiral* infill patterns
+are generally much slower. You might want to avoid them in your draft quality
+prints if you care about slicing speed.
 
 ### Print Settings > Advanced > Resolution
 
-By default, Slic3r does not simplify the input geometry and will render all details into the output G-code for maximum accuracy. However, high-resolution models often carry more resolution than the printer is able to print, so they can be simplified especially when you want faster slicing. You can set the *Resolution* option to something like 0.05mm or even 0.1mm for your draft quality prints.
+By default, Slic3r does not simplify the input geometry and will render all
+details into the output G-code for maximum accuracy. However, high-resolution
+models often carry more resolution than the printer is able to print, so they
+can be simplified especially when you want faster slicing. You can set the
+*Resolution* option to something like 0.05mm or even 0.1mm for your draft
+quality prints.
 
 ### Print settings > Advanced > Threads
 
-(This hint applies to all kind of prints, not just draft quality.)
-Many algorithms in Slic3r support parallelization using multiple threads. You should set this option to the number of processors or cores of your computer.
+(This hint applies to all kind of prints, not just draft quality.) Many
+algorithms in Slic3r support parallelization using multiple threads. You should
+set this option to the number of processors or cores of your computer.

--- a/src/topics/supported-file-formats.md
+++ b/src/topics/supported-file-formats.md
@@ -1,28 +1,50 @@
 # Slic3r Supported File Formats
-Slic3r supports STL, OBJ, AMF formats. This document shows what each format carries and what is supported by Slic3r.
+
+Slic3r supports STL, OBJ, and AMF formats. This document shows what each format
+carries and what is supported by Slic3r.
 
 ## STL
-* Slic3r fully supports STL binary and Ascii files.
-* STL doesn't support color, materials, metadata or other common CAD model attributes. Most of those attributes are not needed for 3D printing.
-* One of the biggest disadvantages in STL format that it doesn't contain a list of all the vertices indices as all vertices are defined in their facets. This problem appear became obvious when you are trying to find whether two facets are neighbors or not, all you can is to compare between vertices numerically which of course having rounding errors. 
+
+* Slic3r fully supports STL binary and ASCII files.
+* STL doesn't support color, materials, metadata or other common CAD model
+  attributes. Most of those attributes are not needed for 3D printing.
+* One of the biggest disadvantages in STL format that it doesn't contain a list
+  of all the vertices indices as all vertices are defined in their facets. This
+  problem becomes obvious when you are trying to find whether two facets are
+  neighbors or not; all you can is to compare between vertices numerically,
+  which of course can be off because of rounding errors.
 
 
 ## OBJ
+
 * Slic3r supports OBJ file formats.
-* OBJ is a simple data format carrying the 3D geometry of the model (its vertices, vertex normals, meshes and UV position of each texture coordinate vertex)
-* OBJ materials are stored in external .mtl files. However, Materials in OBJ format carry information about the color of the facets, their textures, and attributes of a surface according to [Phong reflection model](https://en.wikipedia.org/wiki/Phong_reflection_model) and those attributes are not used in Slic3r as they say nothing about the interior of the object.
+* OBJ is a simple data format carrying the 3D geometry of the model (its
+  vertices, vertex normals, meshes, and UV position of each texture coordinate
+  vertex).
+* OBJ materials are stored in external .mtl files. However, materials in OBJ
+  format carry information about the color of the facets, their textures, and
+  attributes of a surface according to
+  [Phong reflection model](https://en.wikipedia.org/wiki/Phong_reflection_model),
+  and those attributes are not used in Slic3r as they say nothing about the
+  interior of the object.
 
 ### What is supported by Slic3r when reading/writing OBJ files:
-| | Supported in Slic3r |
+
+| Feature | Supported in Slic3r |
 | ------------- |:-------------:|
 | Materials | NO | 
 | Textures and .mtl files | NO |
 
 ## AMF
+
 * Slic3r supports AMF.
-* AMF is by far better than STL, It can represent one object or more objects arranged in a constellation. Also, It can specify the material for each volume in an object. It contains metadata about the objects and other elements.
-* Materials in AMF format are properties of the volumes not just like OBJ format. They carry information about the nature of the surface. These are examples of the materials in AMF XML structure. 
-```
+* AMF is by far better than STL. It can represent one object or more objects
+  arranged in a constellation. Also, It can specify the material for each volume
+  in an object. It contains metadata about the objects and other elements.
+* Materials in AMF format are properties of the volumes, not just like OBJ
+  format. They carry information about the nature of the surface. These are
+  examples of the materials in AMF XML structure. 
+```xml
 <material id="1">
     <metadata type="Name">StiffMaterial</metadata>
   </material>
@@ -49,7 +71,9 @@ Slic3r supports STL, OBJ, AMF formats. This document shows what each format carr
 ```
 
 ### AMF Simple Structure Example
-This Example is a taken from the Wikipedia example but it's more simplified  
+
+This Example is a taken from the Wikipedia example but it's more simplified:
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <amf unit="inch" version="1.1">  <!-- All elements should be contained in the <amf> element -->
@@ -74,18 +98,18 @@ This Example is a taken from the Wikipedia example but it's more simplified
 ```
 
 ### What is supported by Slic3r when reading/writing AMF files:
-| | Supported in Slic3r |
+| Feature | Supported in Slic3r |
 | ------------- |:-------------:|
 | Materials | YES|
 | Metadata | YES |
 | Curved triangles | NO |
 | Constellations | YES |
-| Textures | NO | 
+| Textures | NO |
 
 when writing AMF files, we save additional data which are:
 * Print configuration for each object and each Material.
 * Print configuration for each volume and whether it's a modifier volume or not.
-* Slic3r version in each metadata element in objects, materials, and volumes 
+* Slic3r version in each metadata element in objects, materials, and volumes.
 
 ## References
 * [STL (file format) - Wikipedia](https://en.wikipedia.org/wiki/STL_(file_format))

--- a/src/troubleshooting/dimension-errors.md
+++ b/src/troubleshooting/dimension-errors.md
@@ -1,58 +1,110 @@
 % Dimension Errors
 
-If you're not satisfied by the dimensional accuracy of your prints, first off make sure your **firmware** is correctly configured: the **steps/mm** values for **X, Y, and Z axes** must be calculated according to your belts, pulleys and leadscrews. Please don't calibrate by trial-and-error: those values should be exact. Use Josef Prusa's [Calculator](http://calculator.josefprusa.cz).
+If you're not satisfied by the dimensional accuracy of your prints, first off
+make sure your **firmware** is correctly configured: the **steps/mm** values
+for **X, Y, and Z axes** must be calculated according to your belts, pulleys
+and leadscrews. Please don't calibrate by trial-and-error: those values should
+be exact. Use Josef Prusa's [Calculator](http://calculator.josefprusa.cz).
 
 ### Vertical dimensions
 
-If your vertical dimensions are wrong (i.e. **along the Z axis**) -and your object is usually shorter than expected- it means your nozzle is **too low**, thus the first layer is pressed too much on the print bed. To fix this, you might want to raise your Z endstop or increase the *Z offset* option in Slic3r.
+If your vertical dimensions are wrong (i.e. **along the Z axis**) &mdash; and
+your object is usually shorter than expected &mdash; it means your nozzle is
+**too low**, thus the first layer is pressed too much on the print bed. To fix
+this, you might want to raise your Z endstop or increase the *Z offset* option
+in Slic3r.
 
 ### Horizontal dimensions
 
-The usual issue is about holes being too small. This usually only affects holes on the horizontal plane (XY). There are several reasons for this. Let's see them one by one:
+The usual issue is about holes being too small. This usually only affects holes
+on the horizontal plane (XY). There are several reasons for this. Let's see them
+one by one:
 
 #### Plastic shrinkage
 
-Plastic **shrinks when cooling**. Different kinds of plastic exhibit different shrinkage, which might also depend on temperature. Because of such shrinkage, circular (or polygonal) holes laid by the extruder at the nominal diameter will end up smaller after cooling.
+Plastic **shrinks when cooling**. Different kinds of plastic exhibit different
+shrinkage, which might also depend on temperature. Because of such shrinkage,
+circular (or polygonal) holes laid by the extruder at the nominal diameter will
+end up smaller after cooling.
 
 #### More material is deposited in the inside
 
-When you extrude along a curve, more material per distance unit is deposited in the concave side. Such excessive material makes the internal radius shorter.
-A [compensation algorithm](http://reprap.org/wiki/ArcCompensation) was proposed by Adrian Bowyer, and it was implemented in Slic3r some time ago but many users complained about holes being too large – it was removed thereafter since smaller holes are better than larger holes since they can be drilled.
+When you extrude along a curve, more material per distance unit is deposited in
+the concave side. Such excessive material makes the internal radius shorter.
+A [compensation algorithm](http://reprap.org/wiki/ArcCompensation) was proposed
+by Adrian Bowyer, and it was implemented in Slic3r some time ago but many users
+complained about holes being too large. It was removed thereafter since smaller
+holes are better than larger holes since they can be drilled.
 
 #### Curves are approximated by polygons
 
-STL files only contain meshes composed by flat triangles, so its planar sections can only contain polygonal shapes. For example, a circular hole is approximated by a polygon:
+STL files only contain meshes composed by flat triangles, so its planar sections
+can only contain polygonal shapes. For example, a circular hole is approximated
+by a polygon:
 
-![image](images/dimension-errors/polygonal-hole.png)
+![A hexagon approximates a circle](images/dimension-errors/polygonal-hole.png)
 
-Increasing the **number of segments** in your CAD before exporting the STL file will help reducing the error. OpenSCAD users might want to use the `polyhole()` function developed by [nophead](http://hydraraptor.blogspot.it/2011/02/polyholes.html) that calculates the optimal number of segments.
+Increasing the **number of segments** in your CAD before exporting the STL file
+will help reducing the error. OpenSCAD users might want to use the `polyhole()`
+function developed by [nophead](http://hydraraptor.blogspot.it/2011/02/polyholes.html)
+that calculates the optimal number of segments.
 
 #### Filament tends to cut corners
 
-Since curves are approximated by polygons, there are sharp vertices at their vertices. However, **plastic tends to make rounded corners**, thus reducing the internal area of the hole even more.
+Since curves are approximated by polygons, there are sharp vertices at their
+vertices. However, **plastic tends to make rounded corners**, thus reducing the
+internal area of the hole even more.
 
 #### Z wobble
 
-Even if the dimensional accuracy of a single layer was correct, several stacked layers might make the hole smaller if they're not exactly aligned. [Z wobble](troubleshooting#z-wobble) caused by mechanical issues will reduce hole size to the internal envelope of the stacked layers:
+Even if the dimensional accuracy of a single layer was correct, several stacked
+layers might make the hole smaller if they're not exactly aligned.
+[Z wobble](troubleshooting#z-wobble) caused by mechanical issues will reduce hole
+size to the internal envelope of the stacked layers:
 
-![image](images/dimension-errors/z-wobble.png)
+![Z wobble: Imprecise overlap of successive layers](images/dimension-errors/z-wobble.png)
 
 #### Non-regular filament section
 
-Low-quality and medium-quality filaments are not very regular in diameter. If you measure their diameter along a single meter of them, you'll often find many different values (and many low-quality filaments are even not perfectly round in section). This continuous **variation in diameter** will produce **irregular flow**  and the resulting hole will still be the internal envelope of all the layers:
+Low-quality and medium-quality filaments are not very regular in diameter. If you
+measure their diameter along a single meter of them, you'll often find many
+different values (and many low-quality filaments are even not perfectly round in
+cross section). This continuous **variation in diameter** will produce
+**irregular flow** and the resulting hole will still be the internal envelope of
+all the layers:
 
 ![image](images/dimension-errors/irregular-filament.png)
 
 #### Backlash
 
-Backlash is a mechanical defect of one or more axes that basically reduces the amount of actual motion whenever a motor inverts its spinning direction. It's generally caused by loose belts. On printers with a moving bed, its axis (usually Y) is more subject to backlash because of inertia. So, **if you get different dimension errors in X and Y, that's caused by backlash**. You'll need to tighten your belt. No software hack can reasonably compensate for a badly assembled printer.
+Backlash is a mechanical defect of one or more axes that basically reduces the
+amount of actual motion whenever a motor inverts its spinning direction. It's
+generally caused by loose belts. On printers with a moving bed, its axis (usually
+Y) is more subject to backlash because of inertia. So, **if you get different
+dimension errors in X and Y, that's caused by backlash**. You'll need to tighten
+your belt. No software hack can reasonably compensate for a badly assembled
+printer.
 
 #### Flow math
 
-Okay, all of the above causes do not depend on Slic3r and, when possible, they need to be fixed **before** attempting any software solution.
+Okay, all of the above causes do not depend on Slic3r and, when possible, they
+need to be fixed **before** attempting any software solution.
 
-That said, the flow math used in Slic3r plays a good role in making correct dimensions, since it tries to guess what the shape of the extruded material will be and how thick the extrusion will result on the horizontal plane given an amount of material. Being an approximation, it carries an error. The usual way to deal with these issues involves tuning the *Extrusion Multiplier* setting in order to increase/reduce the amount of plastic, thus making extrusions more or less thick. But this will also affect solid surfaces, so it's not the ideal solution.
+That said, the flow math used in Slic3r plays a good role in making correct
+dimensions, since it tries to guess what the shape of the extruded material will
+be and how thick the extrusion will result on the horizontal plane given an
+amount of material. Being an approximation, it carries an error. The usual way
+to deal with these issues involves tuning the *Extrusion Multiplier* setting in
+order to increase/reduce the amount of plastic, thus making extrusions more or
+less thick. But this will also affect solid surfaces, so it's not the ideal
+solution.
 
-For more exact dimensions you need to check the **External Perimeters First** option. Printing external perimeters first will prevent the shift caused by extrudate overlap. On the other hand, printing internal perimeters first hides seams better, so it's your take.
+For more exact dimensions you need to check the **External Perimeters First**
+option. Printing external perimeters first will prevent the shift caused by
+extrudate overlap. On the other hand, printing internal perimeters first hides
+seams better, so it's your take.
 
-A new **XY Size Compensation** option was also introduced that allows to grow/shrink object shape in order to compensate for the measured error. Supposing your holes are smaller by 0.1mm, you can just enter -0.05 in this option to get them compensated (negative sign means shrink inwards).
+A new **XY Size Compensation** option was also introduced that allows you to
+grow/shrink object shape in order to compensate for the measured error. Supposing
+your holes are smaller by 0.1mm, you can just enter -0.05 in this option to get
+them compensated (negative sign means shrink inwards).


### PR DESCRIPTION
Replaced hyphens with dashes in many places.
Adjusted line lengths to 80-columns (max) in all but a few places.
Stripped trailing spaces as appropriate.
Adjusted _italic_ notation to *italic* in a few notations where there was interference from other underscores.
Corrected typos, spelling, and grammar throughout.
Replaced `which` (which is used for non-essential clauses) with `that` (which is used for essential clauses) throughout.
Etc.