### PR TITLE
Updates `--output` option docs to make directory option more clear.

### DIFF
--- a/src/advanced/command-line.md
+++ b/src/advanced/command-line.md
@@ -65,8 +65,8 @@ slic3r --split cubes.stl
 
 All the `--export-*` actions are affected by the following options:
 
-* `--output FILENAME` (shortcut: `-o`): write output to the given file instead of the default one
-    * if an existing directory is supplied instead of a file, the file will be created inside that directory using the automatically generated file name
+* `--output FILENAME|DIRECTORYNAME` (shortcut: `-o`): write output to the given file or directory instead of the default one
+    * if `DIRECTORYNAME` is supplied, the output file(s) will be created inside that directory using the automatically generated file name
 * `--output-filename-format FORMAT`: this is the string pattern used to define the output file if `--output` is not specified. It defaults to `[input_filename_base].EXT` where EXT is the extension of the output format (`gcode`, `stl` etc.). See the documentation about [placeholders](/advanced/placeholder-parser).
     * when using `--export-svg`, the default format is `[input_filename_base]_[layer_num].svg`
 


### PR DESCRIPTION
Showing the directory name in the command is more noticeable than in a sub-bullet.

When making scripts using the command-line tools this week, I originally thought there was no option for directory output because I missed the sub-bullet. I hope that adding the explicit directory text to this line will make this more clear for future readers.